### PR TITLE
A quick fix on the Engine.Dockerfile

### DIFF
--- a/src/Components/Engine/Engine.Dockerfile
+++ b/src/Components/Engine/Engine.Dockerfile
@@ -21,7 +21,7 @@ RUN python3 -m pip install --upgrade pip
 RUN pip download -r requirements.txt
 RUN pip install -r requirements.txt
 
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-cli -y
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-cli -y
 
 # make the container directory for credentials
 WORKDIR /root


### PR DESCRIPTION
A quick fix on the Engine.Dockerfile Replace the http connection with the https connection to avoid the 502 error from google cloud server.