### PR TITLE
Resolve the 404 error from the post_recording function in map.routes.js

### DIFF
--- a/src/Components/HMI/ui/routes/map.routes.js
+++ b/src/Components/HMI/ui/routes/map.routes.js
@@ -63,15 +63,15 @@ module.exports = function(app) {
 
   app.post(`/post_recording`, async (req, res, next) => {
     let data = req.body
-    axios.post(`${MESSAGE_API_URL}/post_recording`, data)
-    .then(response => {
+    try {
+      const response = await axios.post(`${MESSAGE_API_URL}/post_recording`, data);
       console.log('Record response:', response.data);
-    })
-    .catch(error => {
+      res.send(response.data);
+      next()
+    } catch (error) {
       console.error('Error:', error);
-    });
+    }
     //axios.post(`${MESSAGE_API_URL}/post_recording?data=${recordingData}`);
-    next()
   })
 
   app.post(`/sim_control/:control`, async (req, res, next) => {


### PR DESCRIPTION
Fix the 404 error from the post_recording function in map.routes.js to ensure the recording mode can work correctly.