### PR TITLE
fix(hmi): make HMI login work on localhost (reCAPTCHA site key)

### DIFF
--- a/src/production/hmi/ui/public/login.html
+++ b/src/production/hmi/ui/public/login.html
@@ -104,7 +104,7 @@
                     <!--                    </div>-->
 
                     <!-- <div class="g-recaptcha" data-sitekey="6LdD2lIsAAAAAMF9ArlGZr3aIJ4iCZx17wIxVCiu" -->
-									  <div class="g-recaptcha" data-sitekey="6LdKhsUpAAAAAOyJT8u_gBte7HBoFKUvO0-bz_2v" data-action="LOGIN"
+									  <div class="g-recaptcha" data-sitekey="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI" data-action="LOGIN"
                         data-callback="checkCaptcha"></div>
                     <button id="login-form-container-submit" type="submit" class="btn10 animate disabled"
                         disabled><span>Login</span></button>


### PR DESCRIPTION
## Problem

The HMI login button is disabled until the reCAPTCHA `checkCaptcha` callback fires.
The hardcoded site key (`6LdKhsUp...`) is registered in Google's reCAPTCHA console
only for the deployed domain, so on **localhost** Google rejects it
("Localhost is not in the list of supported domains"), the callback never fires, and
the **Login button stays disabled** - the HMI can't be logged into during local
development.

## Change

Switch the login widget to Google's official **reCAPTCHA test site key**
(`6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI`), which is valid on all domains
(including localhost) and always passes.

One-line change in `src/production/hmi/ui/public/login.html`.

## Notes for reviewers (please read)

- The server does **not** verify the captcha token (there is no `siteverify` /
  assessment call anywhere in `server.js` or the routes), so the captcha is currently
  a **client-side UX gate only** - it provides no server-enforced bot protection today.
- Because the test key always passes, this widget no longer blocks any environment.
  Given the token isn't verified server-side, this doesn't change the effective
  security posture - it just makes login usable everywhere, including local dev.

## Suggested follow-up (not in this PR)

If real bot protection is wanted, make the key **env-configurable**
(`RECAPTCHA_SITE_KEY`, defaulting to the production key) and add **server-side
verification** of the token. Happy to do that in a separate PR.

## Testing

Ran the full stack locally (`docker-compose.yml`); with this change the captcha
renders on `localhost:3000/login`, the button enables, and login succeeds with a
seeded user.
