### PR TITLE
fix(docker): restore missing echo_engine service to docker-compose.yml

### DIFF
--- a/src/deployment/docker/docker-compose.yml
+++ b/src/deployment/docker/docker-compose.yml
@@ -20,6 +20,19 @@ services:
     stdin_open: false
     tty: true
 
+  echo_engine:
+    build:
+      context: ../../production/engine
+      dockerfile: Engine.Dockerfile
+    image: ts-echo-engine
+    container_name: ts-echo-engine-cont
+    networks:
+      - echo-net
+    volumes:
+      - credentials_volume:/root/.config/gcloud/
+    stdin_open: true
+    tty: true
+
   echo_hmi:
     build:
       context: ../../production/hmi


### PR DESCRIPTION
## Problem

After the restructure PR (#935) merged, team members reported the **engine container was missing** — `docker compose up` no longer creates `ts-echo-engine-cont`.

## Cause

The `echo_engine` service was accidentally deleted from `src/deployment/docker/docker-compose.yml` during the restructure, in commit `010cfdf3` ("restructure repository in chunks"). It went from present to gone there and stayed gone through the move + merge.

It survived only in `docker-compose.test.yml` (which is why CI still counted it and the loss went unnoticed until someone ran the **normal** stack). `model_server` (TF Serving, `ts-echo-model-cont`) is still present, so it *looks* like the engine is there when it isn't.

## Fix

Restore the `echo_engine` service, one service block, retargeted to the restructured engine dir:

- `context: ../../production/engine`, `dockerfile: Engine.Dockerfile` — matching `model_server` and the test compose (the original pointed at `Prototypes/engine/torch_impl` / `light_engine.Dockerfile`, now deprecated and moved out).

Validated with `docker compose config`: the stack is back to 10 services and `echo_engine` resolves correctly.

## Note (separate, not addressed here)

Actually *running* the engine still needs GCloud credentials — its entrypoint runs `gcloud auth application-default login` then `python echo_engine.py`. This PR only restores the missing service so the container exists in the normal stack again; the credentials/boot behaviour is a separate follow-up.
