### PR TITLE
Add automated tests for core Engine functions

### DIFF
--- a/src/production/engine/COVERAGE_GAPS.md
+++ b/src/production/engine/COVERAGE_GAPS.md
@@ -1,0 +1,135 @@
+\# Remaining Engine Coverage Gaps
+
+
+
+The Sprint 1 automated test suite covers 46% of
+
+`echo\_engine\_iot.py`. The remaining statements mainly involve
+
+external services, legacy audio modes and model workflows requiring
+
+additional assets.
+
+
+
+\## Real Model Integration
+
+
+
+Model-loading behaviour is tested using mocks. Real integration
+
+testing requires complete Keras, YAMNet or production model files.
+
+
+
+The supplied Engine code does not contain a TensorFlow Lite
+
+Interpreter. Testing the selected TFLite production model requires
+
+coordination with the model-integration team member.
+
+
+
+\## Additional Audio Workflows
+
+
+
+The standard Recording Mode preprocessing path is tested. These paths
+
+remain for future testing:
+
+
+
+\- Recording Mode V2
+
+\- Animal simulation mode
+
+\- Weather-audio prediction
+
+\- Sound-event segmentation
+
+\- Multi-segment audio processing
+
+
+
+\## External Integrations
+
+
+
+These services are mocked in Sprint 1:
+
+
+
+\- Google Cloud Storage
+
+\- MongoDB
+
+\- TensorFlow Serving
+
+\- Backend API
+
+\- MQTT brokers
+
+
+
+Testing them requires approved development services, credentials and
+
+stable interface contracts.
+
+
+
+\## Live MQTT Testing
+
+
+
+`test\_iot\_publisher.py` connects to a public HiveMQ broker by default.
+
+It was not included in the automated execution. Future integration
+
+testing should use a local or private development broker.
+
+
+
+\## Production Alignment
+
+
+
+The automated suite currently targets `echo\_engine\_iot.py`. The team
+
+must confirm when its IoT functionality will be merged into the main
+
+`echo\_engine.py` production file.
+
+
+
+\## Species Configuration
+
+
+
+`class\_names.json` is present but is not read by the supplied Engine
+
+scripts. The Engine currently uses pickle files and species names from
+
+Google Cloud Storage. The intended production source should be
+
+confirmed.
+
+
+
+\## Sprint 2 Recommendations
+
+
+
+1\. Add an approved small model fixture.
+
+2\. Add a local Docker-based MQTT test broker.
+
+3\. Test TensorFlow Serving timeouts and invalid responses.
+
+4\. Test Backend errors and retry behaviour.
+
+5\. Add Recording Mode V2 and weather-audio fixtures.
+
+6\. Confirm the production species mapping.
+
+7\. Repeat the suite against the final production Engine file.

--- a/src/production/engine/TESTING.md
+++ b/src/production/engine/TESTING.md
@@ -1,0 +1,51 @@
+\# Echo Engine Automated Test Instructions
+
+
+
+\## Purpose
+
+
+
+This test suite provides automated coverage for the core Echo Engine
+
+functions required during Sprint 1. It tests configuration loading,
+
+model loading, audio preprocessing, prediction output and IoT message
+
+handling without requiring the complete dataset or live production
+
+services.
+
+
+
+\## Environment
+
+
+
+\- Operating system: Windows
+
+\- Python: 3.9.25
+
+\- Pytest: 8.4.2
+
+\- Coverage.py: 7.10.7
+
+\- Conda environment: projectecho
+
+
+
+\## Installation
+
+
+
+Open Anaconda Prompt and activate the project environment:
+
+
+
+```bat
+
+conda activate projectecho
+
+cd /d D:\\Project-Echo\\src\\production\\engine
+
+python -m pip install pytest pytest-cov

--- a/src/production/engine/TEST_RESULTS_SUMMARY.md
+++ b/src/production/engine/TEST_RESULTS_SUMMARY.md
@@ -1,0 +1,93 @@
+\# Sprint 1 Engine Test Results Summary
+
+
+
+\## Final Results
+
+
+
+\- Tests collected: 44
+
+\- Tests passed: 44
+
+\- Tests failed: 0
+
+\- Engine statements: 456
+
+\- Covered statements: 209
+
+\- Missing statements: 247
+
+\- Final coverage: 46%
+
+\- Execution time: 3.41 seconds
+
+\- Python version: 3.9.25
+
+\- Pytest version: 8.4.2
+
+\- Test date: 6 August 2026
+
+
+
+\## Coverage Improvement
+
+
+
+The original IoT suite contained 16 passing tests and achieved 30%
+
+coverage. I added automated tests for configuration loading, model
+
+loading, preprocessing, prediction output, invalid inputs and Backend
+
+output construction.
+
+
+
+The completed suite contains 44 passing tests and achieves 46%
+
+coverage. This represents 28 additional tests and a 16-percentage-point
+
+coverage improvement.
+
+
+
+\## Areas Tested
+
+
+
+\- IoT payload validation
+
+\- Configuration loading
+
+\- Missing and malformed configuration
+
+\- Keras and YAMNet model loading
+
+\- Missing and corrupt model handling
+
+\- Short WAV preprocessing
+
+\- Empty and invalid audio
+
+\- Species and confidence prediction
+
+\- Base64 audio conversion
+
+\- Edge prediction handling
+
+\- Backend output contract
+
+\- Missing required output fields
+
+
+
+\## Conclusion
+
+
+
+All 44 automated tests passed. The suite provides a reproducible
+
+Sprint 1 baseline for critical Engine functions without requiring the
+
+complete dataset or live production services.

--- a/src/production/engine/echo_engine_iot.py
+++ b/src/production/engine/echo_engine_iot.py
@@ -75,6 +75,27 @@ from sklearn.preprocessing import LabelEncoder
 print('Python Version           : ', python_version())
 print('TensorFlow Version       : ', tf.__version__)
 print('Librosa Version          : ', librosa.__version__)
+def load_keras_model_file(model_path):
+    """
+    Load a Keras model and provide clear errors for invalid paths
+    or corrupt model files.
+    """
+
+    if not isinstance(model_path, str) or not model_path.strip():
+        raise ValueError("Model path must be a non-empty string")
+
+    try:
+        return load_model(model_path)
+
+    except OSError as error:
+        raise FileNotFoundError(
+            f"Model file could not be loaded: {model_path}"
+        ) from error
+
+    except ValueError as error:
+        raise ValueError(
+            f"Invalid or corrupt model file: {model_path}"
+        ) from error
 
 # Load the necessary data and models
 with open('yamnet_dir/class_names.pkl', 'rb') as f:
@@ -86,7 +107,7 @@ with open('yamnet_dir/label_encoder.pkl', 'rb') as f:
 yamnet = yamnet_model.yamnet_frames_model(params)
 yamnet.load_weights('yamnet_dir/yamnet.h5')
 yamnet_classes = yamnet_model.class_names('yamnet_dir/yamnet_class_map.csv')
-model = load_model('yamnet_dir/model_3_82_16000.h5')
+model = load_keras_model_file('yamnet_dir/model_3_82_16000.h5')
 
 # Load the YAMNet model
 # yamnet_model_handle = 'https://tfhub.dev/google/yamnet/1'

--- a/src/production/engine/test_engine_configuration.py
+++ b/src/production/engine/test_engine_configuration.py
@@ -1,0 +1,167 @@
+"""
+Automated tests for Echo Engine configuration loading.
+
+Run from src/production/engine:
+    python -m pytest test_engine_configuration.py -v
+"""
+
+import io
+import json
+import unittest
+from unittest.mock import patch
+
+from test_iot_integration import (
+    EchoEngine,
+    _ENGINE_CONFIG,
+    _ENGINE_CREDS,
+)
+
+_REAL_OPEN = open
+
+
+def controlled_open(config_value):
+    """
+    Return an open function that supplies controlled Engine
+    configuration and credentials.
+    """
+
+    def open_file(path, *args, **kwargs):
+        file_path = str(path)
+
+        if file_path.endswith("echo_engine.json"):
+            if isinstance(config_value, Exception):
+                raise config_value
+
+            return io.StringIO(config_value)
+
+        if file_path.endswith("echo_credentials.json"):
+            return io.StringIO(json.dumps(_ENGINE_CREDS))
+
+        return _REAL_OPEN(path, *args, **kwargs)
+
+    return open_file
+
+
+class TestEngineConfigurationLoading(unittest.TestCase):
+
+    def test_required_configuration_keys_exist(self):
+        engine = EchoEngine()
+
+        required_keys = {
+            "AUDIO_CLIP_DURATION",
+            "AUDIO_SAMPLE_RATE",
+            "AUDIO_NFFT",
+            "AUDIO_STRIDE",
+            "AUDIO_MELS",
+            "MODEL_INPUT_IMAGE_WIDTH",
+            "MODEL_INPUT_IMAGE_HEIGHT",
+            "MODEL_INPUT_IMAGE_CHANNELS",
+            "MODEL_SERVER",
+            "MQTT_CLIENT_URL",
+            "MQTT_CLIENT_PORT",
+            "IOT_MQTT_BROKER",
+            "IOT_MQTT_PORT",
+            "IOT_MQTT_TOPIC",
+        }
+
+        missing_keys = required_keys - set(engine.config)
+
+        self.assertEqual(
+            missing_keys,
+            set(),
+            f"Missing configuration keys: {missing_keys}"
+        )
+
+    def test_configuration_value_types(self):
+        engine = EchoEngine()
+
+        self.assertIsInstance(
+            engine.config["AUDIO_SAMPLE_RATE"],
+            int
+        )
+        self.assertIsInstance(
+            engine.config["AUDIO_CLIP_DURATION"],
+            int
+        )
+        self.assertIsInstance(
+            engine.config["MODEL_SERVER"],
+            str
+        )
+        self.assertIsInstance(
+            engine.config["IOT_MQTT_PORT"],
+            int
+        )
+        self.assertIsInstance(
+            engine.config["IOT_MQTT_TOPIC"],
+            str
+        )
+
+    def test_valid_custom_configuration_loaded(self):
+        test_config = _ENGINE_CONFIG.copy()
+        test_config["MODEL_SERVER"] = (
+            "http://mock-model-server/test"
+        )
+
+        fake_open = controlled_open(
+            json.dumps(test_config)
+        )
+
+        with patch("builtins.open", side_effect=fake_open):
+            engine = EchoEngine()
+
+        self.assertEqual(
+            engine.config["MODEL_SERVER"],
+            "http://mock-model-server/test"
+        )
+        self.assertEqual(
+            engine.config["AUDIO_SAMPLE_RATE"],
+            48000
+        )
+
+    def test_missing_configuration_handled(self):
+        fake_open = controlled_open(
+            FileNotFoundError("echo_engine.json not found")
+        )
+
+        with patch("builtins.open", side_effect=fake_open):
+            with patch("builtins.print") as mock_print:
+                engine = EchoEngine()
+
+        self.assertFalse(hasattr(engine, "config"))
+
+        printed_messages = " ".join(
+            str(call.args[0])
+            for call in mock_print.call_args_list
+            if call.args
+        )
+
+        self.assertIn(
+            "Could not engine config",
+            printed_messages
+        )
+
+    def test_malformed_json_configuration_handled(self):
+        fake_open = controlled_open(
+            '{"AUDIO_SAMPLE_RATE": 48000, invalid}'
+        )
+
+        with patch("builtins.open", side_effect=fake_open):
+            with patch("builtins.print") as mock_print:
+                engine = EchoEngine()
+
+        self.assertFalse(hasattr(engine, "config"))
+
+        printed_messages = " ".join(
+            str(call.args[0])
+            for call in mock_print.call_args_list
+            if call.args
+        )
+
+        self.assertIn(
+            "Could not engine config",
+            printed_messages
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/production/engine/test_engine_core.py
+++ b/src/production/engine/test_engine_core.py
@@ -1,0 +1,189 @@
+"""
+Additional automated tests for core Echo Engine functions.
+
+Run from src/production/engine:
+    python -m pytest test_engine_core.py -v
+"""
+
+import base64
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+from test_iot_integration import (
+    EchoEngine,
+    _make_msg,
+    _valid_payload,
+)
+
+
+class TestCorePrediction(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = EchoEngine()
+        self.engine.class_names = ["Kookaburra", "Magpie"]
+
+    def test_prediction_returns_species_and_percentage(self):
+        mock_tf = sys.modules["tensorflow"]
+
+        mock_tf.argmax.return_value.numpy.return_value = 1
+
+        mock_probability = MagicMock()
+        mock_probability.numpy.return_value = 0.873
+
+        mock_softmax = MagicMock()
+        mock_softmax.__getitem__.return_value = mock_probability
+        mock_tf.nn.softmax.return_value = mock_softmax
+
+        species, confidence = self.engine.predict_class([0.1, 0.9])
+
+        self.assertEqual(species, "Magpie")
+        self.assertEqual(confidence, 87.3)
+
+    def test_invalid_class_index_raises_error(self):
+        mock_tf = sys.modules["tensorflow"]
+        mock_tf.argmax.return_value.numpy.return_value = 10
+
+        with self.assertRaises(IndexError):
+            self.engine.predict_class([0.1, 0.9])
+
+
+class TestAudioEncoding(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = EchoEngine()
+
+    def test_audio_base64_round_trip(self):
+        original_audio = b"RIFF-test-audio-data"
+
+        encoded_audio = self.engine.audio_to_string(original_audio)
+        decoded_audio = self.engine.string_to_audio(encoded_audio)
+
+        self.assertEqual(decoded_audio, original_audio)
+
+    def test_recorded_audio_base64_round_trip(self):
+        original_audio = b"small-recorded-audio-fixture"
+
+        encoded_audio = base64.b64encode(
+            original_audio
+        ).decode("utf-8")
+
+        decoded_audio = self.engine.recorded_string_to_audio(
+            encoded_audio
+        )
+
+        self.assertEqual(decoded_audio, original_audio)
+
+
+class TestEdgePredictionHandling(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = EchoEngine()
+        self.engine.echo_api_send_detection_event = MagicMock()
+
+    def test_valid_edge_prediction_forwarded(self):
+        payload = {
+            "type": "prediction",
+            "species": "Magpie",
+            "confidence": 91.5,
+            "sensor_id": "edge-device-01",
+            "timestamp": "1234567890",
+            "gps_data": {
+                "lat": -37.8136,
+                "lon": 144.9631,
+            },
+            "gps_uncertainty": 4.0,
+        }
+
+        self.engine.on_iot_message(
+            None,
+            None,
+            _make_msg(payload)
+        )
+
+        self.engine.echo_api_send_detection_event.assert_called_once()
+
+        arguments = (
+            self.engine.echo_api_send_detection_event
+            .call_args[0]
+        )
+
+        audio_event = arguments[0]
+        sample_rate = arguments[1]
+        species = arguments[2]
+        confidence = arguments[3]
+
+        self.assertEqual(sample_rate, 0)
+        self.assertEqual(species, "Magpie")
+        self.assertEqual(confidence, 91.5)
+        self.assertEqual(
+            audio_event["sensorId"],
+            "edge-device-01"
+        )
+        self.assertEqual(
+            audio_event["microphoneLLA"],
+            [-37.8136, 144.9631, 0.0]
+        )
+
+    def test_edge_prediction_without_gps_rejected(self):
+        payload = {
+            "type": "prediction",
+            "species": "Magpie",
+            "confidence": 91.5,
+        }
+
+        self.engine.on_iot_message(
+            None,
+            None,
+            _make_msg(payload)
+        )
+
+        self.engine.echo_api_send_detection_event.assert_not_called()
+
+
+class TestIoTNegativeScenarios(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = EchoEngine()
+        self.engine.combined_pipeline = MagicMock()
+        self.engine.echo_api_send_detection_event = MagicMock()
+
+    def test_malformed_json_rejected(self):
+        message = MagicMock()
+        message.payload = b'{"audio_file":'
+
+        self.engine.on_iot_message(None, None, message)
+
+        self.engine.combined_pipeline.assert_not_called()
+        self.engine.echo_api_send_detection_event.assert_not_called()
+
+    def test_invalid_base64_audio_rejected(self):
+        payload = _valid_payload(
+            audio_file="not_base64"
+        )
+
+        self.engine.on_iot_message(
+            None,
+            None,
+            _make_msg(payload)
+        )
+
+        self.engine.combined_pipeline.assert_not_called()
+        self.engine.echo_api_send_detection_event.assert_not_called()
+
+    def test_preprocessing_error_prevents_api_request(self):
+        self.engine.combined_pipeline.side_effect = ValueError(
+            "Invalid or corrupt WAV audio"
+        )
+
+        self.engine.on_iot_message(
+            None,
+            None,
+            _make_msg(_valid_payload())
+        )
+
+        self.engine.echo_api_send_detection_event.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/production/engine/test_engine_model_loading.py
+++ b/src/production/engine/test_engine_model_loading.py
@@ -1,0 +1,81 @@
+"""
+Automated tests for Echo Engine model loading.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Importing this first prepares the mocked heavy dependencies.
+from test_iot_integration import EchoEngine  # noqa: F401
+
+import echo_engine_iot as engine_module
+
+
+class TestEngineModelLoading(unittest.TestCase):
+
+    def test_valid_model_is_returned(self):
+        fake_model = MagicMock(name="fake_keras_model")
+
+        with patch.object(
+            engine_module,
+            "load_model",
+            return_value=fake_model
+        ):
+            result = engine_module.load_keras_model_file(
+                "test_model.h5"
+            )
+
+        self.assertIs(result, fake_model)
+
+    def test_missing_model_file_raises_clear_error(self):
+        with patch.object(
+            engine_module,
+            "load_model",
+            side_effect=OSError("File does not exist")
+        ):
+            with self.assertRaisesRegex(
+                FileNotFoundError,
+                "Model file could not be loaded"
+            ):
+                engine_module.load_keras_model_file(
+                    "missing_model.h5"
+                )
+
+    def test_corrupt_model_file_raises_clear_error(self):
+        with patch.object(
+            engine_module,
+            "load_model",
+            side_effect=ValueError("Invalid model format")
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "Invalid or corrupt model file"
+            ):
+                engine_module.load_keras_model_file(
+                    "corrupt_model.h5"
+                )
+
+    def test_empty_model_path_rejected(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Model path must be a non-empty string"
+        ):
+            engine_module.load_keras_model_file("")
+
+    def test_configured_keras_model_path(self):
+        engine_module.load_model.assert_any_call(
+            "yamnet_dir/model_3_82_16000.h5"
+        )
+
+    def test_yamnet_assets_loaded_from_expected_paths(self):
+        engine_module.yamnet.load_weights.assert_any_call(
+            "yamnet_dir/yamnet.h5"
+        )
+
+        engine_module.tf.saved_model.load.assert_any_call(
+            "yamnet_dir/model"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/production/engine/test_engine_output.py
+++ b/src/production/engine/test_engine_output.py
@@ -1,0 +1,134 @@
+"""
+Automated tests for the Engine prediction output contract.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from test_iot_integration import EchoEngine
+
+import echo_engine_iot as engine_module
+
+
+class TestEnginePredictionOutput(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = EchoEngine()
+        self.engine.config["API_URL"] = (
+            "http://mock-backend/engine/event"
+        )
+
+        self.audio_event = {
+            "timestamp": "2026-08-06T10:30:00Z",
+            "sensorId": "sensor-001",
+            "microphoneLLA": [
+                -37.8136,
+                144.9631,
+                0.0,
+            ],
+            "animalEstLLA": [
+                -37.8136,
+                144.9631,
+                0.0,
+            ],
+            "animalTrueLLA": [
+                -37.8136,
+                144.9631,
+                0.0,
+            ],
+            "animalLLAUncertainty": 5.0,
+            "audioClip": "base64-test-audio",
+        }
+
+    def test_complete_prediction_payload_sent(self):
+        mock_response = MagicMock()
+        mock_response.text = "accepted"
+
+        with patch.object(
+            engine_module.requests,
+            "post",
+            return_value=mock_response
+        ) as mock_post:
+            self.engine.echo_api_send_detection_event(
+                self.audio_event,
+                48000,
+                "Magpie",
+                91.5,
+            )
+
+        expected_payload = {
+            "timestamp": "2026-08-06T10:30:00Z",
+            "species": "Magpie",
+            "confidence": 91.5,
+            "sensorId": "sensor-001",
+            "microphoneLLA": [
+                -37.8136,
+                144.9631,
+                0.0,
+            ],
+            "animalEstLLA": [
+                -37.8136,
+                144.9631,
+                0.0,
+            ],
+            "animalTrueLLA": [
+                -37.8136,
+                144.9631,
+                0.0,
+            ],
+            "animalLLAUncertainty": 5.0,
+            "audioClip": "base64-test-audio",
+            "sampleRate": 48000,
+        }
+
+        mock_post.assert_called_once_with(
+            "http://mock-backend/engine/event",
+            json=expected_payload
+        )
+
+    def test_backend_url_read_from_configuration(self):
+        expected_url = (
+            "http://different-backend/test/event"
+        )
+        self.engine.config["API_URL"] = expected_url
+
+        mock_response = MagicMock()
+        mock_response.text = "accepted"
+
+        with patch.object(
+            engine_module.requests,
+            "post",
+            return_value=mock_response
+        ) as mock_post:
+            self.engine.echo_api_send_detection_event(
+                self.audio_event,
+                48000,
+                "Kookaburra",
+                87.2,
+            )
+
+        actual_url = mock_post.call_args.args[0]
+
+        self.assertEqual(actual_url, expected_url)
+
+    def test_missing_required_output_field_rejected(self):
+        invalid_event = self.audio_event.copy()
+        del invalid_event["timestamp"]
+
+        with patch.object(
+            engine_module.requests,
+            "post"
+        ) as mock_post:
+            with self.assertRaises(KeyError):
+                self.engine.echo_api_send_detection_event(
+                    invalid_event,
+                    48000,
+                    "Magpie",
+                    91.5,
+                )
+
+        mock_post.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/production/engine/test_engine_preprocessing.py
+++ b/src/production/engine/test_engine_preprocessing.py
@@ -1,0 +1,250 @@
+"""
+Automated tests for Echo Engine audio preprocessing.
+
+These tests use a small generated WAV fixture and do not
+require the complete audio dataset.
+"""
+
+import io
+import unittest
+import wave
+from unittest.mock import MagicMock
+
+import numpy as np
+
+# Prepares mocked heavy dependencies before importing the Engine.
+from test_iot_integration import EchoEngine  # noqa: F401
+
+import echo_engine_iot as engine_module
+
+
+def generate_small_wav(
+    duration_seconds=0.10,
+    sample_rate=8000,
+    frequency=440
+):
+    """Generate a small mono WAV fixture in memory."""
+
+    sample_count = int(duration_seconds * sample_rate)
+
+    time_values = np.arange(sample_count) / sample_rate
+
+    samples = (
+        0.25
+        * np.sin(2 * np.pi * frequency * time_values)
+        * 32767
+    ).astype(np.int16)
+
+    wav_buffer = io.BytesIO()
+
+    with wave.open(wav_buffer, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(samples.tobytes())
+
+    return wav_buffer.getvalue()
+
+
+class NumpyTensorResult:
+    """Small TensorFlow-like wrapper providing numpy()."""
+
+    def __init__(self, value):
+        self.value = value
+
+    def numpy(self):
+        return self.value
+
+
+class TestEnginePreprocessing(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = EchoEngine()
+
+        self.processed_audio = np.zeros(
+            48000 * 5,
+            dtype=np.float32
+        )
+
+        self.engine.load_random_subsection = MagicMock(
+            return_value=self.processed_audio
+        )
+
+        # Simulate librosa loading valid audio.
+        engine_module.librosa.load.reset_mock()
+        engine_module.librosa.load.side_effect = None
+        engine_module.librosa.load.return_value = (
+            np.zeros(800, dtype=np.float32),
+            48000,
+        )
+
+        # Simulate a mel-spectrogram with sufficient time frames.
+        mel_spectrogram = np.linspace(
+            0.0,
+            1.0,
+            260 * 1201,
+            dtype=np.float32
+        ).reshape(260, 1201)
+
+        (
+            engine_module.librosa.feature
+            .melspectrogram
+            .reset_mock()
+        )
+
+        (
+            engine_module.librosa.feature
+            .melspectrogram
+            .return_value
+        ) = mel_spectrogram
+
+        engine_module.librosa.power_to_db.reset_mock()
+        engine_module.librosa.power_to_db.return_value = (
+            mel_spectrogram
+        )
+
+        # Configure mocked TensorFlow operations to use NumPy.
+        engine_module.tf.expand_dims.side_effect = (
+            lambda value, axis: np.expand_dims(value, axis)
+        )
+
+        engine_module.tf.repeat.side_effect = (
+            lambda value, repeats, axis:
+            np.repeat(value, repeats, axis=axis)
+        )
+
+        def ensure_shape(value, expected_shape):
+            if list(value.shape) != list(expected_shape):
+                raise ValueError(
+                    f"Unexpected shape: {value.shape}"
+                )
+            return value
+
+        engine_module.tf.ensure_shape.side_effect = ensure_shape
+
+        resized_image = np.linspace(
+            0.0,
+            1.0,
+            260 * 260 * 3,
+            dtype=np.float32
+        ).reshape(260, 260, 3)
+
+        engine_module.tf.image.resize.side_effect = (
+            lambda value, size, method: resized_image.copy()
+        )
+
+        engine_module.tf.reduce_min.side_effect = np.min
+        engine_module.tf.reduce_max.side_effect = np.max
+
+    def test_valid_wav_preprocessing_output(self):
+        wav_fixture = generate_small_wav()
+
+        image, audio, sample_rate = (
+            self.engine.combined_pipeline(
+                wav_fixture,
+                "Recording_Mode"
+            )
+        )
+
+        self.assertEqual(image.shape, (260, 260, 3))
+        self.assertEqual(audio.shape, (48000 * 5,))
+        self.assertEqual(sample_rate, 48000)
+        self.assertTrue(np.isfinite(image).all())
+        self.assertGreaterEqual(float(image.min()), 0.0)
+        self.assertLessEqual(float(image.max()), 1.0)
+
+    def test_preprocessing_uses_configured_sample_rate(self):
+        wav_fixture = generate_small_wav()
+
+        self.engine.combined_pipeline(
+            wav_fixture,
+            "Recording_Mode"
+        )
+
+        load_arguments = (
+            engine_module.librosa.load.call_args
+        )
+
+        loaded_file = load_arguments.args[0]
+        configured_rate = load_arguments.kwargs["sr"]
+
+        self.assertIsInstance(loaded_file, io.BytesIO)
+        self.assertEqual(
+            configured_rate,
+            self.engine.config["AUDIO_SAMPLE_RATE"]
+        )
+
+    def test_corrupt_audio_rejected(self):
+        engine_module.librosa.load.side_effect = ValueError(
+            "Invalid WAV file"
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Invalid WAV file"
+        ):
+            self.engine.combined_pipeline(
+                b"This is not WAV audio",
+                "Recording_Mode"
+            )
+
+    def test_empty_audio_rejected(self):
+        engine_module.librosa.load.side_effect = ValueError(
+            "Audio file is empty"
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Audio file is empty"
+        ):
+            self.engine.combined_pipeline(
+                b"",
+                "Recording_Mode"
+            )
+
+
+class TestAudioSubsection(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = EchoEngine()
+        self.engine.config["AUDIO_SAMPLE_RATE"] = 4
+
+    def test_short_audio_is_padded(self):
+        short_audio = np.array(
+            [0.5, -0.5],
+            dtype=np.float32
+        )
+
+        engine_module.tf.shape.side_effect = (
+            lambda value: np.array(value.shape)
+        )
+
+        engine_module.tf.zeros.side_effect = (
+            lambda shape, dtype:
+            np.zeros(shape, dtype=dtype)
+        )
+
+        engine_module.tf.concat.side_effect = (
+            lambda values, axis:
+            NumpyTensorResult(
+                np.concatenate(values, axis=axis)
+            )
+        )
+
+        result = self.engine.load_random_subsection(
+            short_audio,
+            duration_secs=1
+        )
+
+        self.assertEqual(len(result), 4)
+        np.testing.assert_array_equal(
+            result,
+            np.array(
+                [0.5, -0.5, 0.0, 0.0],
+                dtype=np.float32
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/production/engine/test_iot_integration.py
+++ b/src/production/engine/test_iot_integration.py
@@ -1,5 +1,5 @@
 """
-Unit tests for IoT MQTT integration in echo_engine.py
+Unit tests for IoT MQTT integration in echo_engine_iot.py
 
 Mocks heavy dependencies (TensorFlow, librosa, MQTT, GCP, etc.) so tests
 run without the full Docker stack or GPU.
@@ -176,7 +176,7 @@ class TestIoTMessageHandler(unittest.TestCase):
         # requests.post to model server
         mock_resp = MagicMock()
         mock_resp.text = json.dumps({"outputs": [[0.1, 0.9]]})
-        self.requests_patcher = patch("echo_engine.requests.post", return_value=mock_resp)
+        self.requests_patcher = patch("echo_engine_iot.requests.post",return_value=mock_resp)
         self.mock_post = self.requests_patcher.start()
 
     def tearDown(self):
@@ -229,9 +229,19 @@ class TestIoTMessageHandler(unittest.TestCase):
         self.assertEqual(args[3], 87.3)
 
     def test_model_server_url_from_config(self):
-        self.engine.on_iot_message(None, None, _make_msg(_valid_payload()))
+        expected_url = "http://test-model-server:8501/v1/models/test:predict"
+        self.engine.config["MODEL_SERVER"] = expected_url
+
+        self.engine.on_iot_message(
+            None,
+            None,
+            _make_msg(_valid_payload())
+        )
+
+        self.mock_post.assert_called_once()
         post_url = self.mock_post.call_args[0][0]
-        self.assertEqual(post_url, _ENGINE_CONFIG["MODEL_SERVER"])
+
+        self.assertEqual(post_url, expected_url)
 
 
 # ===========================================================================
@@ -266,6 +276,30 @@ class TestIoTStartupOrder(unittest.TestCase):
         engine.execute()
 
         self.assertEqual(call_order, ["class_names", "iot_listener"])
+    class TestIoTStartupOrder(unittest.TestCase):
+        """Verify IoT listener starts AFTER class_names are loaded."""
+
+    def test_iot_listener_starts_after_class_names(self):
+        engine = EchoEngine()
+        call_order = []
+
+        engine.gcp_load_species_list = MagicMock(
+            side_effect=lambda: (
+                call_order.append("class_names"),
+                ["species"]
+            )[1]
+        )
+
+        engine.start_iot_mqtt_listener = MagicMock(
+            side_effect=lambda: call_order.append("iot_listener")
+        )
+
+        engine.execute()
+
+        self.assertEqual(
+            call_order,
+            ["class_names", "iot_listener"]
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This pull request establishes the Sprint 1 automated testing foundation for core Echo Engine functions.

## Changes

* Added automated tests for IoT payload validation and message handling
* Added configuration-loading and invalid-configuration tests
* Added a testable Keras model-loading wrapper
* Added missing, empty and corrupt model-path tests
* Added audio preprocessing tests using a small generated WAV fixture
* Added prediction, confidence and Base64 conversion tests
* Added edge-inference payload tests
* Added Engine-to-Backend output-contract tests
* Added local execution instructions
* Added a test-results summary and remaining coverage-gap report

## Test Results

* 44 tests collected
* 44 tests passed
* 0 tests failed
* Coverage increased from 30% to 46%
* Python 3.9.25
* Pytest 8.4.2

## Test Command

```bat
python -m pytest test_iot_integration.py test_engine_core.py test_engine_configuration.py test_engine_model_loading.py test_engine_preprocessing.py test_engine_output.py -q
```

## Test Isolation

TensorFlow model execution, TensorFlow Serving, MQTT, MongoDB, Google Cloud Storage and Backend requests are mocked. The automated suite does not connect to live production services or require the complete dataset.

## Remaining Gaps

* Real production-model integration
* TensorFlow Lite integration, which is not present in the supplied Engine code
* Recording Mode V2 and weather-audio testing
* Live MQTT and Backend integration testing
* Final alignment between `echo_engine_iot.py` and the main `echo_engine.py`

Detailed gaps and Sprint 2 recommendations are documented in `COVERAGE_GAPS.md`.
