### PR TITLE
Add Engine-Backend integration test harness

### DIFF
--- a/src/tests/README.md
+++ b/src/tests/README.md
@@ -1,5 +1,7 @@
-# tests
+# Tests
 
-Unit, integration, or system tests.
+Project Echo unit, integration, and system tests.
 
-_Placeholder — no content yet. Delete this README once real files land._
+## Integration tests
+
+- `integration/engine_backend/integration_harness/`: Engine-to-Backend request contract, response handling, timeout, connection-failure, and validation coverage.

--- a/src/tests/integration/engine_backend/integration_harness/README.md
+++ b/src/tests/integration/engine_backend/integration_harness/README.md
@@ -1,0 +1,284 @@
+# Engine-Backend Integration Test Harness
+
+## Purpose
+
+This Sprint 1 harness checks whether a Project Echo Engine detection can be sent to the Backend `POST /engine/event` endpoint. It also checks how the client reports invalid payload responses, timeouts, connection failures, Backend errors, and unexpected response codes.
+
+The harness does not run model inference, MQTT, the simulator, or the HMI.
+
+## Location and Structure
+
+```text
+src/tests/integration/engine_backend/integration_harness/
+|-- client.py
+|-- test_harness.py
+|-- README.md
+`-- fixtures/
+    |-- valid_payloads/
+    |   |-- valid_detection_01.json
+    |   |-- valid_detection_02.json
+    |   |-- valid_detection_03.json
+    |   |-- valid_detection_04.json
+    |   `-- valid_detection_05.json
+    `-- invalid_payloads/
+        |-- invalid_detection_01_missing_species.json
+        |-- invalid_detection_02_confidence_out_of_range.json
+        |-- invalid_detection_03_bad_location.json
+        |-- invalid_detection_04_bad_timestamp.json
+        `-- invalid_detection_05_empty_sensor_id.json
+```
+
+## Files
+
+- `client.py` loads one JSON fixture and sends it to a configurable Backend URL with an explicit timeout.
+- `test_harness.py` uses controlled HTTP mocks to test client response handling without Docker or MongoDB.
+- `fixtures/valid_payloads/` contains five payloads expected to satisfy the current Backend schema.
+- `fixtures/invalid_payloads/` contains five payloads that each break one current Backend validation rule.
+
+## Current Backend Request Contract
+
+The Sprint 1 executable contract is `EventSchema` in `src/production/backend/app/schemas.py`.
+
+| Field | Current requirement |
+|---|---|
+| `timestamp` | Valid date and time |
+| `sensorId` | Non-empty string |
+| `species` | Non-empty string |
+| `microphoneLLA` | Array containing exactly three numbers |
+| `animalEstLLA` | Array containing exactly three numbers |
+| `animalTrueLLA` | Array containing exactly three numbers |
+| `animalLLAUncertainty` | Integer |
+| `audioClip` | String |
+| `confidence` | Number greater than 0 and less than 100 |
+| `sampleRate` | Integer |
+
+The expected successful response is HTTP `201 Created`.
+
+An example valid request is:
+
+```json
+{
+  "timestamp": "2026-08-06T10:15:30Z",
+  "sensorId": "engine-test-sensor-01",
+  "species": "Koala",
+  "microphoneLLA": [-38.143, 144.361, 15.0],
+  "animalEstLLA": [-38.142, 144.36, 15.0],
+  "animalTrueLLA": [-38.142, 144.36, 15.0],
+  "animalLLAUncertainty": 8,
+  "audioClip": "VGVzdCBhdWRpbw==",
+  "confidence": 96.42,
+  "sampleRate": 48000
+}
+```
+
+## Prerequisites
+
+### Automated tests
+
+- Python 3.10 or newer
+- No third-party Python packages required
+- Docker is not required
+
+### Live Backend tests
+
+- Docker Desktop running
+- Project Echo Backend and MongoDB images built
+- Local port `9000` available for the Backend
+
+## Run the Automated Tests
+
+Run this command from the Project Echo repository root:
+
+```powershell
+& C:\Users\maddi\AppData\Local\Microsoft\WindowsApps\python3.11.exe src\tests\integration\engine_backend\integration_harness\test_harness.py
+```
+
+Expected summary:
+
+```text
+Ran 6 tests
+OK
+```
+
+These are simulated client tests. They mock HTTP responses and do not prove that the real Backend or MongoDB is running.
+
+The successful-response test sends all five valid fixtures through the mocked client path. The invalid-response test sends all five invalid fixtures through a mocked HTTP `422` path.
+
+## Start the Development Backend
+
+From the repository root:
+
+```powershell
+cd src\deployment\docker
+docker compose up -d echo_store echo_api
+docker compose ps
+cd ..\..\..
+```
+
+Confirm that the API documentation opens at `http://localhost:9000/docs` and displays `POST /engine/event`.
+
+## Run One Live Valid Request
+
+From the repository root:
+
+```powershell
+& C:\Users\maddi\AppData\Local\Microsoft\WindowsApps\python3.11.exe src\tests\integration\engine_backend\integration_harness\client.py
+```
+
+The client uses `fixtures/valid_payloads/valid_detection_01.json` by default and sends it to:
+
+```text
+http://localhost:9000/engine/event
+```
+
+Expected result:
+
+```text
+PASS: Backend returned HTTP 201
+```
+
+This live request should insert one test event into the development MongoDB database.
+
+## Run One Live Invalid Request
+
+From the repository root:
+
+```powershell
+& C:\Users\maddi\AppData\Local\Microsoft\WindowsApps\python3.11.exe src\tests\integration\engine_backend\integration_harness\client.py --payload src\tests\integration\engine_backend\integration_harness\fixtures\invalid_payloads\invalid_detection_01_missing_species.json
+```
+
+Expected result:
+
+```text
+FAIL: Backend returned HTTP 422
+```
+
+This failure is expected because the payload does not contain `species`.
+
+## Optional Client Arguments
+
+Use another Backend URL or timeout without editing source code:
+
+```powershell
+& C:\Users\maddi\AppData\Local\Microsoft\WindowsApps\python3.11.exe src\tests\integration\engine_backend\integration_harness\client.py --url http://localhost:9000/engine/event --timeout 5
+```
+
+### Select another fixture
+
+Do not edit `client.py` to change the fixture. The path to `valid_detection_01.json` in `client.py` is only the default used when no `--payload` argument is supplied.
+
+Select any other fixture by passing its complete path through `--payload`.
+
+Valid case 2:
+
+```powershell
+& C:\Users\maddi\AppData\Local\Microsoft\WindowsApps\python3.11.exe src\tests\integration\engine_backend\integration_harness\client.py --payload src\tests\integration\engine_backend\integration_harness\fixtures\valid_payloads\valid_detection_02.json
+```
+
+Valid case 3:
+
+```powershell
+& C:\Users\maddi\AppData\Local\Microsoft\WindowsApps\python3.11.exe src\tests\integration\engine_backend\integration_harness\client.py --payload src\tests\integration\engine_backend\integration_harness\fixtures\valid_payloads\valid_detection_03.json
+```
+
+Valid case 4:
+
+```powershell
+& C:\Users\maddi\AppData\Local\Microsoft\WindowsApps\python3.11.exe src\tests\integration\engine_backend\integration_harness\client.py --payload src\tests\integration\engine_backend\integration_harness\fixtures\valid_payloads\valid_detection_04.json
+```
+
+Valid case 5:
+
+```powershell
+& C:\Users\maddi\AppData\Local\Microsoft\WindowsApps\python3.11.exe src\tests\integration\engine_backend\integration_harness\client.py --payload src\tests\integration\engine_backend\integration_harness\fixtures\valid_payloads\valid_detection_05.json
+```
+
+Invalid missing-species case:
+
+```powershell
+& C:\Users\maddi\AppData\Local\Microsoft\WindowsApps\python3.11.exe src\tests\integration\engine_backend\integration_harness\client.py --payload src\tests\integration\engine_backend\integration_harness\fixtures\invalid_payloads\invalid_detection_01_missing_species.json
+```
+
+Each live valid request creates a separate test record in the development MongoDB database. Running all five live cases is optional unless requested by the Engine or Backend lead.
+
+## Fixture Coverage
+
+### Valid payloads
+
+| Fixture | Main variation |
+|---|---|
+| `valid_detection_01.json` | Koala, 48,000 Hz |
+| `valid_detection_02.json` | Uperoleia mimula, 32,000 Hz |
+| `valid_detection_03.json` | Sulphur-crested Cockatoo, timezone offset, 44,100 Hz |
+| `valid_detection_04.json` | Australian Magpie, 22,050 Hz |
+| `valid_detection_05.json` | Laughing Kookaburra, 16,000 Hz |
+
+### Invalid payloads
+
+| Fixture | Expected validation problem |
+|---|---|
+| `invalid_detection_01_missing_species.json` | Required `species` field is missing |
+| `invalid_detection_02_confidence_out_of_range.json` | Confidence is exactly 100; current schema requires less than 100 |
+| `invalid_detection_03_bad_location.json` | `microphoneLLA` contains two values instead of three |
+| `invalid_detection_04_bad_timestamp.json` | Timestamp is not a valid date and time |
+| `invalid_detection_05_empty_sensor_id.json` | `sensorId` is empty |
+
+## Automated Validation Coverage
+
+| Test group | Simulated expected result |
+|---|---|
+| Five valid payloads | HTTP `201` accepted |
+| Five invalid payloads | HTTP `422` reported |
+| Request timeout | Controlled timeout error |
+| Backend unavailable | Controlled connection error |
+| Backend server failure | HTTP `500` reported |
+| Unexpected HTTP `200` | Contract failure reported |
+
+The mocked tests verify client behaviour. At least one valid and one invalid request should also be tested against the real development Backend for Sprint 1 evidence.
+
+## Live-Test Evidence to Record
+
+After live testing, record:
+
+- Test date
+- Python version
+- Backend URL
+- Fixture filename
+- Expected HTTP status
+- Actual HTTP status
+- Returned event ID for the valid request
+- MongoDB storage confirmation
+- Pass or fail result
+
+Do not state that a live test passed until the request has actually been run against the development Backend.
+
+## Current Interface Mismatches
+
+1. `echo_engine_iot.py` reads `API_URL` from `echo_engine.json`, while `echo_engine.py` hardcodes the Backend URL.
+2. The existing Engine sender does not set an explicit request timeout.
+3. The existing Engine sender prints the response body but does not explicitly check for HTTP `201`.
+4. The existing Engine sender does not catch timeout or connection errors locally.
+5. The current Backend uses three-element arrays for locations; Anand's proposed interface uses named location objects.
+6. The current Backend requires integer `animalLLAUncertainty`; the proposed interface shows a decimal value.
+7. Proposed `status` and `error` fields are not part of the current stored-event schema.
+
+## Sprint 2 Recommendations
+
+1. Agree on one versioned Engine-Backend contract.
+2. Clarify whether the inference response and stored detection event are separate contracts.
+3. Standardise Backend URL configuration across Engine implementations.
+4. Add an agreed production timeout, structured logging, and controlled error handling.
+5. Decide whether real detections require `animalTrueLLA` and the complete Base64 audio clip.
+6. Decide whether location uncertainty must support decimal values.
+7. Evaluate bounded retries or queued delivery for temporary Backend outages.
+8. Run an end-to-end test using a real model prediction.
+
+## Troubleshooting
+
+- `Payload file not found`: verify that the path includes `fixtures/valid_payloads/` or `fixtures/invalid_payloads/`.
+- `Could not connect to Backend`: confirm Docker Desktop, `echo_store`, and `echo_api` are running.
+- HTTP `422`: compare the fixture with `EventSchema` and read the response details.
+- HTTP `500`: run `docker compose logs echo_api` and `docker compose logs echo_store` from `src/deployment/docker`.
+- Timeout: confirm the Backend URL and check `http://localhost:9000/docs`.
+
+Do not commit credentials, real sensitive recordings, generated `__pycache__` files, or unrelated model changes.

--- a/src/tests/integration/engine_backend/integration_harness/client.py
+++ b/src/tests/integration/engine_backend/integration_harness/client.py
@@ -1,0 +1,150 @@
+"""Send a Project Echo detection event to the Backend API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+from urllib import error, request
+
+
+DEFAULT_BACKEND_URL = "http://localhost:9000/engine/event"
+DEFAULT_TIMEOUT_SECONDS = 5.0
+
+
+class HarnessError(RuntimeError):
+    """Base error raised by the Engine-Backend integration client."""
+
+
+class PayloadError(HarnessError):
+    """Raised when a payload file cannot be used."""
+
+
+class BackendRequestError(HarnessError):
+    """Raised when the Backend rejects a request or cannot be reached."""
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+@dataclass(frozen=True)
+class BackendResponse:
+    """Successful response returned by the Backend."""
+
+    status_code: int
+    body: Any
+
+
+def load_payload(path: str | Path) -> dict[str, Any]:
+    """Load one JSON object from a fixture file."""
+
+    payload_path = Path(path)
+    try:
+        with payload_path.open("r", encoding="utf-8") as file:
+            payload = json.load(file)
+    except FileNotFoundError as exc:
+        raise PayloadError(f"Payload file not found: {payload_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise PayloadError(f"Payload file is not valid JSON: {payload_path}") from exc
+
+    if not isinstance(payload, dict):
+        raise PayloadError("The payload must be a JSON object.")
+    return payload
+
+
+def send_detection(
+    backend_url: str,
+    payload: Mapping[str, Any],
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> BackendResponse:
+    """POST a detection and accept only the current Backend success code, 201."""
+
+    if timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be greater than zero")
+
+    encoded_payload = json.dumps(dict(payload)).encode("utf-8")
+    http_request = request.Request(
+        backend_url,
+        data=encoded_payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    try:
+        with request.urlopen(http_request, timeout=timeout_seconds) as response:
+            raw_body = response.read().decode("utf-8")
+            try:
+                body = json.loads(raw_body) if raw_body else {}
+            except json.JSONDecodeError:
+                body = raw_body
+
+            if response.status != 201:
+                raise BackendRequestError(
+                    f"Unexpected Backend status {response.status}",
+                    status_code=response.status,
+                )
+            return BackendResponse(status_code=response.status, body=body)
+    except error.HTTPError as exc:
+        details = exc.read().decode("utf-8", errors="replace")
+        raise BackendRequestError(
+            f"Backend returned HTTP {exc.code}: {details}",
+            status_code=exc.code,
+        ) from exc
+    except (socket.timeout, TimeoutError) as exc:
+        raise BackendRequestError(
+            f"Backend request timed out after {timeout_seconds} seconds"
+        ) from exc
+    except error.URLError as exc:
+        if isinstance(exc.reason, (socket.timeout, TimeoutError)):
+            raise BackendRequestError(
+                f"Backend request timed out after {timeout_seconds} seconds"
+            ) from exc
+        raise BackendRequestError(f"Could not connect to Backend: {exc.reason}") from exc
+
+
+def main() -> int:
+    """Run one manual Engine-to-Backend integration request."""
+
+    fixture = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "valid_payloads"
+        / "valid_detection_01.json"
+    )
+    parser = argparse.ArgumentParser(
+        description="Send a Project Echo detection fixture to the Backend."
+    )
+    parser.add_argument(
+        "--url",
+        default=os.getenv("ECHO_BACKEND_URL", DEFAULT_BACKEND_URL),
+        help="Backend event endpoint",
+    )
+    parser.add_argument("--payload", default=str(fixture), help="JSON payload file")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="Request timeout in seconds",
+    )
+    args = parser.parse_args()
+
+    try:
+        payload = load_payload(args.payload)
+        response = send_detection(args.url, payload, args.timeout)
+    except (HarnessError, ValueError) as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"PASS: Backend returned HTTP {response.status_code}")
+    print(json.dumps(response.body, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tests/integration/engine_backend/integration_harness/fixtures/invalid_payloads/invalid_detection_01_missing_species.json
+++ b/src/tests/integration/engine_backend/integration_harness/fixtures/invalid_payloads/invalid_detection_01_missing_species.json
@@ -1,0 +1,11 @@
+{
+  "timestamp": "2026-08-06T10:15:30Z",
+  "sensorId": "engine-test-invalid-01",
+  "microphoneLLA": [-38.143, 144.361, 15.0],
+  "animalEstLLA": [-38.142, 144.36, 15.0],
+  "animalTrueLLA": [-38.142, 144.36, 15.0],
+  "animalLLAUncertainty": 8,
+  "audioClip": "VGVzdCBhdWRpbw==",
+  "confidence": 96.42,
+  "sampleRate": 48000
+}

--- a/src/tests/integration/engine_backend/integration_harness/fixtures/invalid_payloads/invalid_detection_02_confidence_out_of_range.json
+++ b/src/tests/integration/engine_backend/integration_harness/fixtures/invalid_payloads/invalid_detection_02_confidence_out_of_range.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2026-08-06T10:15:30Z",
+  "sensorId": "engine-test-invalid-02",
+  "species": "Koala",
+  "microphoneLLA": [-38.143, 144.361, 15.0],
+  "animalEstLLA": [-38.142, 144.36, 15.0],
+  "animalTrueLLA": [-38.142, 144.36, 15.0],
+  "animalLLAUncertainty": 8,
+  "audioClip": "VGVzdCBhdWRpbw==",
+  "confidence": 100.0,
+  "sampleRate": 48000
+}

--- a/src/tests/integration/engine_backend/integration_harness/fixtures/invalid_payloads/invalid_detection_03_bad_location.json
+++ b/src/tests/integration/engine_backend/integration_harness/fixtures/invalid_payloads/invalid_detection_03_bad_location.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2026-08-06T10:15:30Z",
+  "sensorId": "engine-test-invalid-03",
+  "species": "Koala",
+  "microphoneLLA": [-38.143, 144.361],
+  "animalEstLLA": [-38.142, 144.36, 15.0],
+  "animalTrueLLA": [-38.142, 144.36, 15.0],
+  "animalLLAUncertainty": 8,
+  "audioClip": "VGVzdCBhdWRpbw==",
+  "confidence": 96.42,
+  "sampleRate": 48000
+}

--- a/src/tests/integration/engine_backend/integration_harness/fixtures/invalid_payloads/invalid_detection_04_bad_timestamp.json
+++ b/src/tests/integration/engine_backend/integration_harness/fixtures/invalid_payloads/invalid_detection_04_bad_timestamp.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "not-a-valid-timestamp",
+  "sensorId": "engine-test-invalid-04",
+  "species": "Koala",
+  "microphoneLLA": [-38.143, 144.361, 15.0],
+  "animalEstLLA": [-38.142, 144.36, 15.0],
+  "animalTrueLLA": [-38.142, 144.36, 15.0],
+  "animalLLAUncertainty": 8,
+  "audioClip": "VGVzdCBhdWRpbw==",
+  "confidence": 96.42,
+  "sampleRate": 48000
+}

--- a/src/tests/integration/engine_backend/integration_harness/fixtures/invalid_payloads/invalid_detection_05_empty_sensor_id.json
+++ b/src/tests/integration/engine_backend/integration_harness/fixtures/invalid_payloads/invalid_detection_05_empty_sensor_id.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2026-08-06T10:15:30Z",
+  "sensorId": "",
+  "species": "Koala",
+  "microphoneLLA": [-38.143, 144.361, 15.0],
+  "animalEstLLA": [-38.142, 144.36, 15.0],
+  "animalTrueLLA": [-38.142, 144.36, 15.0],
+  "animalLLAUncertainty": 8,
+  "audioClip": "VGVzdCBhdWRpbw==",
+  "confidence": 96.42,
+  "sampleRate": 48000
+}

--- a/src/tests/integration/engine_backend/integration_harness/fixtures/valid_payloads/valid_detection_01.json
+++ b/src/tests/integration/engine_backend/integration_harness/fixtures/valid_payloads/valid_detection_01.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2026-08-06T10:15:30Z",
+  "sensorId": "engine-test-sensor-01",
+  "species": "Koala",
+  "microphoneLLA": [-38.143, 144.361, 15.0],
+  "animalEstLLA": [-38.142, 144.36, 15.0],
+  "animalTrueLLA": [-38.142, 144.36, 15.0],
+  "animalLLAUncertainty": 8,
+  "audioClip": "VGVzdCBhdWRpbw==",
+  "confidence": 96.42,
+  "sampleRate": 48000
+}

--- a/src/tests/integration/engine_backend/integration_harness/fixtures/valid_payloads/valid_detection_02.json
+++ b/src/tests/integration/engine_backend/integration_harness/fixtures/valid_payloads/valid_detection_02.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2026-08-06T10:16:00Z",
+  "sensorId": "engine-test-sensor-02",
+  "species": "Uperoleia mimula",
+  "microphoneLLA": [-38.808104, 143.591356, 10.0],
+  "animalEstLLA": [-38.808294, 143.592951, 4.607966],
+  "animalTrueLLA": [-38.808298, 143.592957, 10.0],
+  "animalLLAUncertainty": 0,
+  "audioClip": "VGVzdCBhdWRpbyAy",
+  "confidence": 99.36,
+  "sampleRate": 32000
+}

--- a/src/tests/integration/engine_backend/integration_harness/fixtures/valid_payloads/valid_detection_03.json
+++ b/src/tests/integration/engine_backend/integration_harness/fixtures/valid_payloads/valid_detection_03.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2026-08-06T10:17:00+10:00",
+  "sensorId": "engine-test-sensor-03",
+  "species": "Sulphur-crested Cockatoo",
+  "microphoneLLA": [-37.8136, 144.9631, 12.0],
+  "animalEstLLA": [-37.8134, 144.9634, 9.0],
+  "animalTrueLLA": [-37.8133, 144.9635, 10.0],
+  "animalLLAUncertainty": 5,
+  "audioClip": "VGVzdCBhdWRpbyAz",
+  "confidence": 82.75,
+  "sampleRate": 44100
+}

--- a/src/tests/integration/engine_backend/integration_harness/fixtures/valid_payloads/valid_detection_04.json
+++ b/src/tests/integration/engine_backend/integration_harness/fixtures/valid_payloads/valid_detection_04.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2026-08-06T00:18:00Z",
+  "sensorId": "engine-test-sensor-04",
+  "species": "Australian Magpie",
+  "microphoneLLA": [-35.2809, 149.13, 20.0],
+  "animalEstLLA": [-35.2811, 149.1303, 18.0],
+  "animalTrueLLA": [-35.281, 149.1302, 19.0],
+  "animalLLAUncertainty": 12,
+  "audioClip": "VGVzdCBhdWRpbyA0",
+  "confidence": 74.1,
+  "sampleRate": 22050
+}

--- a/src/tests/integration/engine_backend/integration_harness/fixtures/valid_payloads/valid_detection_05.json
+++ b/src/tests/integration/engine_backend/integration_harness/fixtures/valid_payloads/valid_detection_05.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2026-08-06T10:19:00Z",
+  "sensorId": "engine-test-sensor-05",
+  "species": "Laughing Kookaburra",
+  "microphoneLLA": [-33.8688, 151.2093, 25.0],
+  "animalEstLLA": [-33.8686, 151.2096, 21.0],
+  "animalTrueLLA": [-33.8685, 151.2097, 22.0],
+  "animalLLAUncertainty": 3,
+  "audioClip": "VGVzdCBhdWRpbyA1",
+  "confidence": 88.5,
+  "sampleRate": 16000
+}

--- a/src/tests/integration/engine_backend/integration_harness/test_harness.py
+++ b/src/tests/integration/engine_backend/integration_harness/test_harness.py
@@ -1,0 +1,118 @@
+"""Automated tests for the Engine-to-Backend integration client."""
+
+from __future__ import annotations
+
+import json
+import socket
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from urllib import error
+
+from client import BackendRequestError, load_payload, send_detection
+
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+class ResponseContext:
+    """Small context-manager response used by the standard-library mocks."""
+
+    def __init__(self, status: int, body: object) -> None:
+        self.status = status
+        self._body = json.dumps(body).encode("utf-8")
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "ResponseContext":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+def make_http_error(status: int, body: str) -> error.HTTPError:
+    """Create an HTTP error with a readable response body."""
+
+    response_body = MagicMock()
+    response_body.read.return_value = body.encode("utf-8")
+    http_error = error.HTTPError(
+        url="http://localhost:9000/engine/event",
+        code=status,
+        msg=body,
+        hdrs=None,
+        fp=response_body,
+    )
+    return http_error
+
+
+class IntegrationHarnessTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.backend_url = "http://localhost:9000/engine/event"
+        self.valid_fixtures = sorted(
+            (FIXTURES / "valid_payloads").glob("valid_detection_*.json")
+        )
+        self.invalid_fixtures = sorted(
+            (FIXTURES / "invalid_payloads").glob("invalid_detection_*.json")
+        )
+        self.valid_payload = load_payload(self.valid_fixtures[0])
+
+    @patch("client.request.urlopen")
+    def test_successful_simulated_request(self, mock_urlopen: MagicMock) -> None:
+        mock_urlopen.return_value = ResponseContext(201, {"_id": "test-event-id"})
+
+        self.assertEqual(len(self.valid_fixtures), 5)
+        for fixture in self.valid_fixtures:
+            with self.subTest(fixture=fixture.name):
+                response = send_detection(self.backend_url, load_payload(fixture))
+                self.assertEqual(response.status_code, 201)
+                self.assertEqual(response.body["_id"], "test-event-id")
+
+    @patch("client.request.urlopen")
+    def test_invalid_payload_returns_422(self, mock_urlopen: MagicMock) -> None:
+        def reject_payload(*args: object, **kwargs: object) -> None:
+            raise make_http_error(422, '{"detail":"payload validation failed"}')
+
+        mock_urlopen.side_effect = reject_payload
+
+        self.assertEqual(len(self.invalid_fixtures), 5)
+        for fixture in self.invalid_fixtures:
+            with self.subTest(fixture=fixture.name):
+                with self.assertRaises(BackendRequestError) as raised:
+                    send_detection(self.backend_url, load_payload(fixture))
+                self.assertEqual(raised.exception.status_code, 422)
+
+    @patch("client.request.urlopen", side_effect=socket.timeout("timed out"))
+    def test_timeout_is_reported(self, mock_urlopen: MagicMock) -> None:
+        with self.assertRaisesRegex(BackendRequestError, "timed out"):
+            send_detection(self.backend_url, self.valid_payload, timeout_seconds=0.1)
+
+    @patch("client.request.urlopen")
+    def test_connection_failure_is_reported(self, mock_urlopen: MagicMock) -> None:
+        mock_urlopen.side_effect = error.URLError("connection refused")
+
+        with self.assertRaisesRegex(BackendRequestError, "Could not connect"):
+            send_detection(self.backend_url, self.valid_payload)
+
+    @patch("client.request.urlopen")
+    def test_backend_500_is_reported(self, mock_urlopen: MagicMock) -> None:
+        mock_urlopen.side_effect = make_http_error(500, "storage failure")
+
+        with self.assertRaises(BackendRequestError) as raised:
+            send_detection(self.backend_url, self.valid_payload)
+
+        self.assertEqual(raised.exception.status_code, 500)
+
+    @patch("client.request.urlopen")
+    def test_unexpected_success_status_is_rejected(
+        self, mock_urlopen: MagicMock
+    ) -> None:
+        mock_urlopen.return_value = ResponseContext(200, {"message": "unexpected"})
+
+        with self.assertRaisesRegex(BackendRequestError, "Unexpected Backend status 200"):
+            send_detection(self.backend_url, self.valid_payload)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

This pull request adds the Sprint 1 Engine–Backend Integration Test Harness.

## Changes

- Added an integration client for `POST /engine/event`.
- Added five valid payload fixtures.
- Added five invalid payload fixtures.
- Added tests for:
  - HTTP 201 success
  - HTTP 422 invalid payload
  - HTTP 500 Backend error
  - Request timeout
  - Connection failure
  - Unexpected success status
- Added configurable Backend URL, payload file and timeout options.
- Added a README with setup instructions, commands, payload details, validation coverage, interface mismatches and Sprint 2 recommendations.

## Testing

All six automated test groups passed.

A live request to the development Backend also returned HTTP 201 Created.

## Notes

The harness follows the current Backend array-based location format. Proposed payload changes, including named location objects and `status`/`error` fields, are documented for future team discussion.