### PR TITLE
C7.1: Add compound index idx_timestamp_species on detections collection

### DIFF
--- a/src/production/infrastructure/mongodb/migrations/002_create_detections_indexes.js
+++ b/src/production/infrastructure/mongodb/migrations/002_create_detections_indexes.js
@@ -1,0 +1,9 @@
+// C7.1 - Create indexes on detections collection
+db = db.getSiblingDB("EchoNet");
+
+db.detections.createIndex(
+  { timestamp: -1, species: 1 },
+  { name: "idx_timestamp_species" }
+);
+
+print("Index idx_timestamp_species created successfully.");


### PR DESCRIPTION
Added compound index `idx_timestamp_species` ({timestamp: -1, species: 1}) on the `detections` collection to optimize queries filtering by species and timestamp.

Verified with .explain("executionStats") — confirms the index is used correctly (IXSCAN) and avoids full collection scans on the target query pattern.