### PR TITLE
C7.2: Add migration script for timestamp/species index with history tracking

### DIFF
--- a/src/production/infrastructure/mongodb/migrations/001_add_timestamp_species_index.js
+++ b/src/production/infrastructure/mongodb/migrations/001_add_timestamp_species_index.js
@@ -1,0 +1,11 @@
+// This file creates one index which is a shortcut for searching fast and easily
+// on the detections collection, sorted by timestamp and species. 
+
+const migrationDb = db.getSiblingDB("EchoNet");
+
+migrationDb.detections.createIndex(
+  { timestamp: -1, species: 1 },
+  { name: "idx_timestamp_species" }
+);
+
+print("Done: index created on detections collection");

--- a/src/production/infrastructure/mongodb/migrations/migrate.js
+++ b/src/production/infrastructure/mongodb/migrations/migrate.js
@@ -1,0 +1,16 @@
+// Thia file checks: has migration 001 already run before?
+// If not, run it. If yes, skip it. 
+
+const migrationsDb = db.getSiblingDB("EchoNet");
+const historyBook = migrationsDb.migrations_history;
+
+const alreadyDone = historyBook.findOne({ _id: "001" });
+
+if (alreadyDone) {
+  print("Already done, skipping migration 001");
+} else {
+  print("Running migration 001 now...");
+  load("/migrations/001_add_timestamp_species_index.js");
+  historyBook.insertOne({ _id: "001", appliedAt: new Date() });
+  print("Migration 001 done and saved to history");
+}


### PR DESCRIPTION
Added migration script `001_add_timestamp_species_index.js` to create the compound index `idx_timestamp_species` on the `detections` collection.

Added `migrate.js` runner script that checks `migrations_history` before applying migrations, preventing duplicate runs.

Tested via `docker compose up echo_migrate` — confirmed migration runs successfully and correctly skips re-applying an already-completed migration (verified via `migrations_history` collection).