### PR TITLE
FR-D2: Back the admin notifications with real data and render them sa…

### DIFF
--- a/src/production/hmi/ui/middleware/index.js
+++ b/src/production/hmi/ui/middleware/index.js
@@ -79,6 +79,57 @@ function _isPublicRoute(path) {
 const checkUserSession = createCheckUserSession(client, _isPublicRoute);
 
 // ─────────────────────────────────────────────────────────────────────────────
+// API session guard
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build a session guard for routes that answer with JSON.
+ *
+ * checkUserSession above redirects to /login when there is no session, which is
+ * right for a page but wrong for an API: axios follows the redirect, gets the
+ * login page back with a 200, and the caller ends up parsing HTML as JSON. That
+ * is the same failure that had to be fixed in the sign-in route. This replies
+ * with a status the caller can actually act on instead.
+ *
+ * The token lookup is passed in so the guard can be tested without Redis.
+ *
+ * @param {() => Promise<string|null>} getToken
+ * @returns {import('express').RequestHandler}
+ */
+function createApiSessionGuard(getToken) {
+  return async function apiSessionGuard(req, res, next) {
+    try {
+      const token = await getToken();
+
+      if (!token) {
+        return res.status(401).json({
+          error: "Your session has expired. Please sign in again."
+        });
+      }
+
+      return next();
+    } catch (error) {
+      // Redis being unreachable is our problem rather than the caller's, so this
+      // is a 503 and not a 401. A 401 would tell them to sign in again, which
+      // would not help and would lose whatever they were doing.
+      console.error("API session check failed (Redis error):", error);
+      return res.status(503).json({
+        error: "Unable to verify your session. Please try again shortly."
+      });
+    }
+  };
+}
+
+/**
+ * Session guard for JSON API routes, backed by the same Redis JWT that
+ * checkUserSession reads.
+ */
+const requireApiSession = createApiSessionGuard(async () => {
+  await ensureRedisConnected();
+  return client.get("JWT");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Session helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -110,6 +161,8 @@ async function clearUserSession() {
 module.exports = {
   verifySignUp,
   checkUserSession,
+  createApiSessionGuard,
+  requireApiSession,
   clearUserSession,
   client,
 };

--- a/src/production/hmi/ui/package.json
+++ b/src/production/hmi/ui/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-     "test": "node --test tests/nodes-overlay.test.mjs public/js/audio_recorder.test.mjs tests/razorpay-payment.test.js tests/paymentgateway.test.js",
+     "test": "node --test tests/nodes-overlay.test.mjs tests/notifications.test.mjs public/js/audio_recorder.test.mjs tests/razorpay-payment.test.js tests/paymentgateway.test.js",
     "dev": "nodemon --inspect=0.0.0.0 server.js"
   },
   "author": "",

--- a/src/production/hmi/ui/package.json
+++ b/src/production/hmi/ui/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-     "test": "node --test tests/nodes-overlay.test.mjs tests/notifications.test.mjs public/js/audio_recorder.test.mjs tests/razorpay-payment.test.js tests/paymentgateway.test.js",
+     "test": "node --test tests/nodes-overlay.test.mjs tests/notifications.test.mjs tests/api-session-guard.test.mjs public/js/audio_recorder.test.mjs tests/razorpay-payment.test.js tests/paymentgateway.test.js",
     "dev": "nodemon --inspect=0.0.0.0 server.js"
   },
   "author": "",

--- a/src/production/hmi/ui/public/admin/component/header-component.html
+++ b/src/production/hmi/ui/public/admin/component/header-component.html
@@ -27,6 +27,28 @@
       background-color: var(--echo-green) !important;
       color: #ffffff !important;
     }
+
+    /* Unread count that sits on the bell. Lives with the header so it styles
+       the same on every admin page the component is dropped into. */
+    .nav-icon-hover { position: relative; }
+
+    .notification-badge {
+      position: absolute;
+      top: 2px;
+      right: 2px;
+      min-width: 18px;
+      height: 18px;
+      padding: 0 5px;
+      border-radius: 9px;
+      background-color: #C8473C;
+      color: #ffffff;
+      font-size: 11px;
+      line-height: 18px;
+      font-weight: 600;
+      text-align: center;
+    }
+
+    .notification-badge[hidden] { display: none; }
   </style>
     <nav class="navbar navbar-expand-lg navbar-light">
       <ul class="navbar-nav">
@@ -36,10 +58,12 @@
           </a>
         </li>
         <li class="nav-item">
-          <a class="nav-link nav-icon-hover" href="javascript:void(0)">
+          <a class="nav-link nav-icon-hover" href="/notifications">
             <i class="ti ti-bell-ringing" style="color: #2F6E4F;"></i>
-            <class id="notification-badge" >
-            </class>
+            <!-- was a <class> tag, which is not an element at all, so the unread
+                 count had nothing to render into. Hidden until there is a count
+                 to show. -->
+            <span id="notification-badge" class="notification-badge" hidden></span>
           </a>
         </li>
       </ul>

--- a/src/production/hmi/ui/public/admin/js/notifications.js
+++ b/src/production/hmi/ui/public/admin/js/notifications.js
@@ -1,129 +1,243 @@
-$(document).ready(function() {
-    // Dummy notifications for testing
-    let notifications = [
-        {
-            id: 1,
-            message: "New donation received from Jon Doe",
-            date: new Date(),
-            read: false,
-            icon: "ti ti-receipt-2",
-            type: "donation"
-        },
-        {
-            id: 2,
-            message: "New request from Jon Doe",
-            date: new Date(Date.now() - 3600000), // 1 hour ago
-            read: false,
-            icon: "ti ti-alert-circle",
-            type: "request"
-        },
-        {
-            id: 3,
-            message: "New user registration: jondoe@example.com",
-            date: new Date(Date.now() - 172800000), // 2 days ago
-            read: false,
-            icon: "ti ti-user",
-            type: "user"
-        }
-    ];
-    console.log("Initial notifications:", notifications);
-    console.log("Unread count:", notifications.filter(n => !n.read).length);
+// =============================================================
+// Admin notifications
+//
+// Loads the feed from /api/notifications and sends every action straight back
+// to the server, so read, delete and mark-all-read all survive a refresh.
+//
+// Nothing here builds an element out of an HTML string. Notification text comes
+// from donation and account records, which means it is effectively user
+// supplied, and dropping that into innerHTML would let a crafted email address
+// run script in the admin console. Everything is created with the DOM API and
+// written in with textContent instead.
+// =============================================================
 
-    // Render notifications
-    function renderNotifications() {
-        const notificationContainer = $("#notification-list");
-        notificationContainer.empty();
+import {
+  retrieveNotifications,
+  markNotificationRead,
+  markAllNotificationsRead,
+  deleteNotification,
+  deleteReadNotifications
+} from "/js/routes.js";
+import { getApiErrorMessage } from "/js/HMI-utils.js";
 
-        if (notifications.length === 0) {
-            notificationContainer.html(`
-                <div class="empty-notifications">
-                    <i class="far fa-bell-slash"></i>
-                    <h5>No notifications</h5>
-                    <p>You're all caught up!</p>
-                </div>
-            `);
-            return;
-        }
+const pageState = window.createAdminPageState ? window.createAdminPageState() : null;
 
-        // Sort by date (newest first)
-        notifications.sort((a, b) => b.date - a.date);
+// The single copy of what the server last told us. The list and the badge are
+// both drawn from this, so they cannot disagree.
+let notifications = [];
+let unreadCount = 0;
 
-        notifications.forEach(notification => {
-            const timeAgo = moment(notification.date).fromNow();
-            const formattedDate = moment(notification.date).format('MMM D, YYYY h:mm A');
-            const notificationItem = `
-                <div class="d-flex align-items-start notification-item ${notification.read ? 'read' : 'unread'}" data-id="${notification.id}">
-                    <div class="notification-icon">
-                        <i class="${notification.icon}"></i>
-                    </div>
-                    <div class="notification-content">
-                        <p class="notification-message mb-1">${notification.message}</p>
-                        <p class="notification-date mb-2"><small><i class="far fa-clock me-1"></i>${timeAgo} (${formattedDate})</small></p>
-                        <div class="notification-actions">
-                            <button class="btn btn-sm ${notification.read ? 'btn-outline-secondary' : 'btn-outline-primary'} mark-read" ${notification.read ? 'disabled' : ''}>
-                                <i class="fas fa-check me-1"></i>${notification.read ? 'Read' : 'Mark Read'}
-                            </button>
-                            <button class="btn btn-sm btn-outline-danger delete-notification">
-                                <i class="fas fa-trash-alt me-1"></i>Delete
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            `;
-            notificationContainer.append(notificationItem);
-        });
-    }
+// Icons are chosen here from the notification type rather than taken from the
+// response, so nothing outside this file can decide what class lands on an
+// element.
+const ICONS_BY_TYPE = {
+  donation: "ti ti-receipt-2",
+  request: "ti ti-alert-circle",
+  user: "ti ti-user"
+};
 
-    //Function to update notification permissions (display unread count)
-    function updateNotificationBadge() {
-        const unreadCount = notifications.filter(notification => !notification.read).length;
-        const badge = $("#notification-badge");    
-        if (unreadCount > 0) {
-            badge.text(unreadCount);
-            badge.show();
-        } else {
-            badge.hide();
-        }
-    }
-    
-    // Mark notification as read
-    $(document).on("click", ".mark-read", function () {
-        const notificationId = $(this).closest(".notification-item").data("id");
-        const notification = notifications.find(n => n.id === notificationId);
-        if (notification) {
-            notification.read = true;
-            renderNotifications();
-        }
-        updateNotificationBadge();
+const DEFAULT_ICON = "ti ti-bell";
+
+function createElement(tag, className, text) {
+  const element = document.createElement(tag);
+  if (className) element.className = className;
+  if (text !== undefined) element.textContent = text;
+  return element;
+}
+
+function formatWhen(rawDate) {
+  const date = new Date(rawDate);
+  if (Number.isNaN(date.getTime())) return "";
+
+  if (typeof window.moment === "function") {
+    const when = window.moment(date);
+    return `${when.fromNow()} (${when.format("MMM D, YYYY h:mm A")})`;
+  }
+
+  return date.toLocaleString();
+}
+
+function buildEmptyState() {
+  const wrapper = createElement("div", "empty-notifications");
+  wrapper.appendChild(createElement("i", "far fa-bell-slash"));
+  wrapper.appendChild(createElement("h5", null, "No notifications"));
+  wrapper.appendChild(createElement("p", null, "You're all caught up!"));
+  return wrapper;
+}
+
+function buildNotificationItem(notification) {
+  const item = createElement(
+    "div",
+    `d-flex align-items-start notification-item ${notification.read ? "read" : "unread"}`
+  );
+  item.dataset.id = notification.id;
+
+  const iconWrapper = createElement("div", "notification-icon");
+  iconWrapper.appendChild(
+    createElement("i", ICONS_BY_TYPE[notification.type] || DEFAULT_ICON)
+  );
+  item.appendChild(iconWrapper);
+
+  const content = createElement("div", "notification-content");
+
+  // textContent, so a message containing markup is shown as text rather than parsed
+  content.appendChild(
+    createElement("p", "notification-message mb-1", notification.message)
+  );
+
+  const dateLine = createElement("p", "notification-date mb-2");
+  const dateSmall = createElement("small");
+  dateSmall.appendChild(createElement("i", "far fa-clock me-1"));
+  dateSmall.appendChild(document.createTextNode(formatWhen(notification.date)));
+  dateLine.appendChild(dateSmall);
+  content.appendChild(dateLine);
+
+  const actions = createElement("div", "notification-actions");
+
+  const readButton = createElement(
+    "button",
+    `btn btn-sm ${notification.read ? "btn-outline-secondary" : "btn-outline-primary"} mark-read`
+  );
+  readButton.type = "button";
+  readButton.disabled = Boolean(notification.read);
+  readButton.appendChild(createElement("i", "fas fa-check me-1"));
+  readButton.appendChild(
+    document.createTextNode(notification.read ? "Read" : "Mark Read")
+  );
+  actions.appendChild(readButton);
+
+  const deleteButton = createElement("button", "btn btn-sm btn-outline-danger delete-notification");
+  deleteButton.type = "button";
+  deleteButton.appendChild(createElement("i", "fas fa-trash-alt me-1"));
+  deleteButton.appendChild(document.createTextNode("Delete"));
+  actions.appendChild(deleteButton);
+
+  content.appendChild(actions);
+  item.appendChild(content);
+
+  return item;
+}
+
+function renderList() {
+  const container = document.getElementById("notification-list");
+  if (!container) return;
+
+  container.replaceChildren();
+
+  if (notifications.length === 0) {
+    container.appendChild(buildEmptyState());
+    return;
+  }
+
+  for (const notification of notifications) {
+    container.appendChild(buildNotificationItem(notification));
+  }
+}
+
+// The header is injected after this script runs, so the badge may not exist yet.
+// renderBadge is safe to call at any point and is re-run once the header lands.
+function renderBadge() {
+  const badge = document.getElementById("notification-badge");
+  if (!badge) return;
+
+  badge.textContent = unreadCount > 0 ? String(unreadCount) : "";
+  badge.hidden = unreadCount === 0;
+  badge.setAttribute(
+    "aria-label",
+    unreadCount === 1 ? "1 unread notification" : `${unreadCount} unread notifications`
+  );
+}
+
+// Only place that draws anything, so the badge can never fall out of step with
+// the list it is counting.
+function render() {
+  renderList();
+  renderBadge();
+}
+
+function applyResult(data) {
+  notifications = Array.isArray(data && data.notifications) ? data.notifications : [];
+  unreadCount = Number.isFinite(data && data.unreadCount)
+    ? data.unreadCount
+    : notifications.filter(item => !item.read).length;
+  render();
+}
+
+async function runAction(action, failureMessage) {
+  if (pageState) {
+    pageState.hideError();
+    pageState.showLoading();
+  }
+
+  try {
+    const response = await action();
+    applyResult(response.data);
+  } catch (error) {
+    console.error(failureMessage, error);
+    if (pageState) pageState.showError(getApiErrorMessage(error, failureMessage));
+  } finally {
+    if (pageState) pageState.hideLoading();
+  }
+}
+
+function idFromEvent(event, selector) {
+  const button = event.target.closest(selector);
+  if (!button) return null;
+
+  const item = button.closest(".notification-item");
+  return item ? item.dataset.id : null;
+}
+
+function wireUp() {
+  const container = document.getElementById("notification-list");
+  if (container) {
+    // delegated, so buttons rebuilt on every render stay wired up
+    container.addEventListener("click", event => {
+      const readId = idFromEvent(event, ".mark-read");
+      if (readId) {
+        runAction(() => markNotificationRead(readId), "Could not mark the notification as read.");
+        return;
+      }
+
+      const deleteId = idFromEvent(event, ".delete-notification");
+      if (deleteId) {
+        runAction(() => deleteNotification(deleteId), "Could not delete the notification.");
+      }
     });
+  }
 
-    // Delete notification
-    $(document).on("click", ".delete-notification", function () {
-        const notificationId = $(this).closest(".notification-item").data("id");
-        notifications = notifications.filter(n => n.id !== notificationId);
-        renderNotifications();
-        updateNotificationBadge();
+  const markAllButton = document.getElementById("mark-all-read");
+  if (markAllButton) {
+    markAllButton.addEventListener("click", () =>
+      runAction(markAllNotificationsRead, "Could not mark all notifications as read.")
+    );
+  }
+
+  const deleteReadButton = document.getElementById("delete-all-read");
+  if (deleteReadButton) {
+    deleteReadButton.addEventListener("click", () =>
+      runAction(deleteReadNotifications, "Could not delete the read notifications.")
+    );
+  }
+
+  // The header component is loaded in separately, so watch for it arriving and
+  // paint the badge then rather than guessing at a delay.
+  //
+  // The badge itself sits inside #header, so the observer has to stop as soon as
+  // it has what it wants. Leaving it connected means renderBadge's own write
+  // counts as a mutation, which calls renderBadge again, and the page locks up.
+  const header = document.getElementById("header");
+  if (header && !document.getElementById("notification-badge")) {
+    const observer = new MutationObserver(() => {
+      if (!document.getElementById("notification-badge")) return;
+      observer.disconnect();
+      renderBadge();
     });
+    observer.observe(header, { childList: true, subtree: true });
+  }
+}
 
-    // Mark all as read
-    $("#mark-all-read").on("click", function () {
-        notifications.forEach(notification => {
-            notification.read = true;
-        });
-        renderNotifications();
-        updateNotificationBadge();
-    });
+wireUp();
+runAction(retrieveNotifications, "Could not load notifications.");
 
-    // Delete all read notifications
-    $("#delete-all-read").on("click", function () {
-        notifications = notifications.filter(n => !n.read);
-        renderNotifications();
-        updateNotificationBadge();
-    });
-
-    renderNotifications();
-    updateNotificationBadge();
-    setTimeout(function() {
-    updateNotificationBadge();
-    }, 100);
-});
+export { buildNotificationItem, renderBadge, applyResult };

--- a/src/production/hmi/ui/public/admin/js/notifications.js
+++ b/src/production/hmi/ui/public/admin/js/notifications.js
@@ -174,7 +174,12 @@ async function runAction(action, failureMessage) {
     applyResult(response.data);
   } catch (error) {
     console.error(failureMessage, error);
-    if (pageState) pageState.showError(getApiErrorMessage(error, failureMessage));
+    // The API sends a specific reason for the cases it knows about, an expired
+    // session in particular, so prefer that over the generic mapping.
+    const serverMessage = error && error.response && error.response.data && error.response.data.error;
+    if (pageState) {
+      pageState.showError(serverMessage || getApiErrorMessage(error, failureMessage));
+    }
   } finally {
     if (pageState) pageState.hideLoading();
   }

--- a/src/production/hmi/ui/public/admin/notifications.html
+++ b/src/production/hmi/ui/public/admin/notifications.html
@@ -23,10 +23,14 @@
   ></script>
 
 
-  <script type="text/javascript" src="/admin/js/notifications.js"></script>
-
   <!-- Shared admin page state -->
   <script type="text/javascript" src="/admin/js/admin-page-state.js"></script>
+
+  <!-- axios has to load before the module below - routes.js grabs window.axios
+       as soon as it evaluates, so this one can't be deferred -->
+  <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+
+  <script type="module" src="/admin/js/notifications.js"></script>
 
   <!-- Fixed CSS path -->
   <link rel="stylesheet" type="text/css" href="/admin/css/notifications.css" />

--- a/src/production/hmi/ui/public/js/routes.js
+++ b/src/production/hmi/ui/public/js/routes.js
@@ -134,3 +134,49 @@ export function stopSimulator()        { return api.post("/sim_control/Stop"); }
 export function retrieveSimTime() {
   return withRetry(() => api.get("/latest_movement"), RETRY_OPTS);
 }
+
+// -----------------------------------------------------------------------------
+// Admin notifications  (FR-D2)
+//
+// Every action returns the refreshed list, so the caller never has to guess what
+// the server now holds or keep a second copy of the list in sync by hand.
+// -----------------------------------------------------------------------------
+
+/** @returns {Promise<AxiosResponse>}  response.data is { notifications, unreadCount }. */
+export function retrieveNotifications() {
+  return withRetry(() => api.get("/api/notifications"), RETRY_OPTS);
+}
+
+/**
+ * PATCH - not retried, this changes the notification rather than reading it.
+ * @param {string} notificationId
+ * @returns {Promise<AxiosResponse>}
+ */
+export function markNotificationRead(notificationId) {
+  return api.patch(`/api/notifications/${encodeURIComponent(notificationId)}/read`);
+}
+
+/**
+ * PATCH - not retried, same reasoning as above.
+ * @returns {Promise<AxiosResponse>}
+ */
+export function markAllNotificationsRead() {
+  return api.patch("/api/notifications/read-all");
+}
+
+/**
+ * DELETE - not retried, we do not want to risk repeating a removal.
+ * @param {string} notificationId
+ * @returns {Promise<AxiosResponse>}
+ */
+export function deleteNotification(notificationId) {
+  return api.delete(`/api/notifications/${encodeURIComponent(notificationId)}`);
+}
+
+/**
+ * DELETE - not retried, same reasoning as above.
+ * @returns {Promise<AxiosResponse>}
+ */
+export function deleteReadNotifications() {
+  return api.delete("/api/notifications/read");
+}

--- a/src/production/hmi/ui/server.js
+++ b/src/production/hmi/ui/server.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const cookieSession = require('cookie-session');
 const helmet = require('helmet');
 const jwt = require('jsonwebtoken');
-const { client, checkUserSession } = require('./middleware');
+const { client, checkUserSession, requireApiSession } = require('./middleware');
 const controller = require('./controller/auth.controller');
 const crypto = require('crypto');
 const bcrypt = require('bcryptjs');
@@ -758,7 +758,10 @@ async function setNotificationFlags(ids, flags) {
   return result.upsertedCount + result.modifiedCount;
 }
 
-app.get('/api/notifications', async (req, res) => {
+// The feed carries donor emails and account details, so every route here is
+// behind a session. requireApiSession answers 401 JSON rather than redirecting
+// to /login the way the page guard does, which a browser API caller cannot use.
+app.get('/api/notifications', requireApiSession, async (req, res) => {
   try {
     res.json(await listNotifications());
   } catch (error) {
@@ -769,7 +772,7 @@ app.get('/api/notifications', async (req, res) => {
 
 // Declared before the /:id routes below, otherwise "read-all" and "read" get
 // swallowed as an id.
-app.patch('/api/notifications/read-all', async (req, res) => {
+app.patch('/api/notifications/read-all', requireApiSession, async (req, res) => {
   try {
     const { notifications } = await listNotifications();
     const unreadIds = notifications.filter(item => !item.read).map(item => item.id);
@@ -781,7 +784,7 @@ app.patch('/api/notifications/read-all', async (req, res) => {
   }
 });
 
-app.delete('/api/notifications/read', async (req, res) => {
+app.delete('/api/notifications/read', requireApiSession, async (req, res) => {
   try {
     const { notifications } = await listNotifications();
     const readIds = notifications.filter(item => item.read).map(item => item.id);
@@ -793,7 +796,7 @@ app.delete('/api/notifications/read', async (req, res) => {
   }
 });
 
-app.patch('/api/notifications/:id/read', async (req, res) => {
+app.patch('/api/notifications/:id/read', requireApiSession, async (req, res) => {
   try {
     await setNotificationFlags([req.params.id], { read: true });
     res.json(await listNotifications());
@@ -803,7 +806,7 @@ app.patch('/api/notifications/:id/read', async (req, res) => {
   }
 });
 
-app.delete('/api/notifications/:id', async (req, res) => {
+app.delete('/api/notifications/:id', requireApiSession, async (req, res) => {
   try {
     await setNotificationFlags([req.params.id], { deleted: true });
     res.json(await listNotifications());

--- a/src/production/hmi/ui/server.js
+++ b/src/production/hmi/ui/server.js
@@ -699,6 +699,120 @@ app.get("/notifications", (req,res) => {
   res.sendFile(path.join(__dirname, 'public/admin/notifications.html'))
 })
 
+// ============================================================
+// Admin notifications
+//
+// The admin notification list used to be a hardcoded array in the browser, so
+// nothing survived a refresh. The feed is now built from records we already
+// hold (donations and user registrations) and the read/deleted state is kept in
+// its own collection, keyed by a stable id per source record. That way marking
+// something read is still true after a reload, and we are not duplicating the
+// donation or user documents just to track a flag against them.
+// ============================================================
+
+const NOTIFICATION_STATE_COLLECTION = 'notificationState';
+const notificationFeed = require('./services/notifications');
+
+async function getEchoNetDb() {
+  if (!connectedDB) {
+    await donationClient.connect();
+    connectedDB = donationClient.db('EchoNet');
+    console.log('Reconnected to MongoDB for notifications');
+  }
+  return connectedDB;
+}
+
+// Reads only. The shaping and the read/deleted join live in
+// services/notifications.js so they can be tested without Mongo or the server.
+async function listNotifications() {
+  const db = await getEchoNetDb();
+
+  const donations = await db.collection('donations').find({}).toArray();
+  const users = await donationClient
+    .db('UserSample')
+    .collection('users')
+    .find({}, { projection: { email: 1, username: 1, createdAt: 1 } })
+    .toArray();
+  const stateRows = await db.collection(NOTIFICATION_STATE_COLLECTION).find({}).toArray();
+
+  return notificationFeed.applyState(
+    notificationFeed.buildFeed({ donations, users }),
+    stateRows
+  );
+}
+
+// One place to write a flag so the four actions cannot drift apart.
+async function setNotificationFlags(ids, flags) {
+  if (ids.length === 0) return 0;
+
+  const db = await getEchoNetDb();
+  const operations = ids.map(id => ({
+    updateOne: {
+      filter: { _id: id },
+      update: { $set: { ...flags, updatedAt: new Date() } },
+      upsert: true
+    }
+  }));
+
+  const result = await db.collection(NOTIFICATION_STATE_COLLECTION).bulkWrite(operations);
+  return result.upsertedCount + result.modifiedCount;
+}
+
+app.get('/api/notifications', async (req, res) => {
+  try {
+    res.json(await listNotifications());
+  } catch (error) {
+    console.error('Error loading notifications:', error);
+    res.status(500).json({ error: 'Unable to load notifications.' });
+  }
+});
+
+// Declared before the /:id routes below, otherwise "read-all" and "read" get
+// swallowed as an id.
+app.patch('/api/notifications/read-all', async (req, res) => {
+  try {
+    const { notifications } = await listNotifications();
+    const unreadIds = notifications.filter(item => !item.read).map(item => item.id);
+    await setNotificationFlags(unreadIds, { read: true });
+    res.json(await listNotifications());
+  } catch (error) {
+    console.error('Error marking all notifications read:', error);
+    res.status(500).json({ error: 'Unable to mark notifications as read.' });
+  }
+});
+
+app.delete('/api/notifications/read', async (req, res) => {
+  try {
+    const { notifications } = await listNotifications();
+    const readIds = notifications.filter(item => item.read).map(item => item.id);
+    await setNotificationFlags(readIds, { deleted: true });
+    res.json(await listNotifications());
+  } catch (error) {
+    console.error('Error deleting read notifications:', error);
+    res.status(500).json({ error: 'Unable to delete read notifications.' });
+  }
+});
+
+app.patch('/api/notifications/:id/read', async (req, res) => {
+  try {
+    await setNotificationFlags([req.params.id], { read: true });
+    res.json(await listNotifications());
+  } catch (error) {
+    console.error('Error marking notification read:', error);
+    res.status(500).json({ error: 'Unable to mark the notification as read.' });
+  }
+});
+
+app.delete('/api/notifications/:id', async (req, res) => {
+  try {
+    await setNotificationFlags([req.params.id], { deleted: true });
+    res.json(await listNotifications());
+  } catch (error) {
+    console.error('Error deleting notification:', error);
+    res.status(500).json({ error: 'Unable to delete the notification.' });
+  }
+});
+
 //API endpoint for patching the new review status to the newly reviewed edit request
 app.patch('/api/requests/:id', async (req, res) => {
   const requestId = req.params.id; // Get the request ID from the URL parameter

--- a/src/production/hmi/ui/services/notifications.js
+++ b/src/production/hmi/ui/services/notifications.js
@@ -1,0 +1,83 @@
+"use strict";
+
+/**
+ * Admin notification feed assembly.
+ *
+ * The admin notification list used to be a hardcoded array in the browser, so
+ * nothing survived a refresh. The feed is now derived from records we already
+ * hold (donations and user registrations) and the read/deleted state is stored
+ * separately, keyed by a stable id per source record.
+ *
+ * The pure parts live here rather than in server.js so they can be tested
+ * without booting the server or touching Mongo. server.js does the reads and
+ * hands the documents in.
+ */
+
+const ANONYMOUS_DONOR = "an anonymous supporter";
+const UNKNOWN_ACCOUNT = "unknown account";
+
+/**
+ * Build notification entries out of the source records.
+ *
+ * The id is derived from the source document rather than generated, otherwise
+ * the read state would not line up with the same notification on the next
+ * request and everything would look unread again after a reload.
+ *
+ * @param {{donations?: object[], users?: object[]}} sources
+ * @returns {object[]}
+ */
+function buildFeed({ donations = [], users = [] } = {}) {
+  const feed = [];
+
+  for (const donation of donations) {
+    const email = donation.billing_details && donation.billing_details.email;
+    feed.push({
+      id: `donation:${donation._id}`,
+      type: "donation",
+      message: `New donation received from ${email || ANONYMOUS_DONOR}`,
+      // Stripe records seconds, JavaScript wants milliseconds
+      date: donation.created ? new Date(donation.created * 1000) : new Date(0)
+    });
+  }
+
+  for (const user of users) {
+    feed.push({
+      id: `user:${user._id}`,
+      type: "user",
+      message: `New user registration: ${user.email || user.username || UNKNOWN_ACCOUNT}`,
+      date: user.createdAt ? new Date(user.createdAt) : new Date(0)
+    });
+  }
+
+  return feed;
+}
+
+/**
+ * Join the stored read/deleted flags onto the feed.
+ *
+ * Deleted entries are dropped rather than returned with a flag, so the browser
+ * never has to know they existed. unreadCount is derived from the same list it
+ * is counting, which is what keeps the badge and the list from disagreeing.
+ *
+ * @param {object[]} feed
+ * @param {object[]} stateRows  Documents of { _id, read, deleted }.
+ * @returns {{notifications: object[], unreadCount: number}}
+ */
+function applyState(feed = [], stateRows = []) {
+  const byId = new Map();
+  for (const row of stateRows) {
+    byId.set(row._id, row);
+  }
+
+  const notifications = feed
+    .filter(item => !(byId.get(item.id) || {}).deleted)
+    .map(item => ({ ...item, read: Boolean((byId.get(item.id) || {}).read) }))
+    .sort((a, b) => b.date - a.date);
+
+  return {
+    notifications,
+    unreadCount: notifications.filter(item => !item.read).length
+  };
+}
+
+module.exports = { buildFeed, applyState };

--- a/src/production/hmi/ui/tests/api-session-guard.test.mjs
+++ b/src/production/hmi/ui/tests/api-session-guard.test.mjs
@@ -1,0 +1,95 @@
+"use strict";
+
+/**
+ * Tests for the JSON session guard used by the notification API.
+ *
+ * createApiSessionGuard takes the token lookup as an argument, so these run
+ * against the real guard without Redis. The point of the guard is that it never
+ * answers with a redirect: the page guard sends a browser to /login, and an API
+ * caller following that redirect gets the login page back with a 200 and tries
+ * to parse HTML as JSON.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import middleware from "../middleware/index.js";
+
+const { createApiSessionGuard } = middleware;
+
+function fakeRes() {
+  const res = { statusCode: null, body: null, redirectedTo: null };
+  res.status = code => { res.statusCode = code; return res; };
+  res.json = body => { res.body = body; return res; };
+  res.redirect = target => { res.redirectedTo = target; return res; };
+  return res;
+}
+
+test("calls through when a session token is present", async () => {
+  const guard = createApiSessionGuard(async () => "a-token");
+  const res = fakeRes();
+  let calledNext = false;
+
+  await guard({}, res, () => { calledNext = true; });
+
+  assert.equal(calledNext, true);
+  assert.equal(res.statusCode, null);
+});
+
+test("answers 401 when there is no token", async () => {
+  const guard = createApiSessionGuard(async () => null);
+  const res = fakeRes();
+  let calledNext = false;
+
+  await guard({}, res, () => { calledNext = true; });
+
+  assert.equal(calledNext, false);
+  assert.equal(res.statusCode, 401);
+});
+
+test("401 carries a JSON body and never a redirect", async () => {
+  const guard = createApiSessionGuard(async () => null);
+  const res = fakeRes();
+
+  await guard({}, res, () => {});
+
+  assert.equal(res.redirectedTo, null);
+  assert.equal(typeof res.body, "object");
+  assert.match(res.body.error, /sign in/i);
+});
+
+test("an empty string token counts as no session", async () => {
+  const guard = createApiSessionGuard(async () => "");
+  const res = fakeRes();
+
+  await guard({}, res, () => {});
+
+  assert.equal(res.statusCode, 401);
+});
+
+test("a Redis failure is a 503, not a 401", async () => {
+  const guard = createApiSessionGuard(async () => {
+    throw new Error("Redis unreachable");
+  });
+  const res = fakeRes();
+  let calledNext = false;
+
+  await guard({}, res, () => { calledNext = true; });
+
+  // telling someone to sign in again would not help and would lose their work
+  assert.equal(res.statusCode, 503);
+  assert.equal(calledNext, false);
+  assert.equal(res.redirectedTo, null);
+});
+
+test("the guard never leaks the underlying error to the caller", async () => {
+  const guard = createApiSessionGuard(async () => {
+    throw new Error("connect ECONNREFUSED 10.0.0.5:6379");
+  });
+  const res = fakeRes();
+
+  await guard({}, res, () => {});
+
+  assert.doesNotMatch(res.body.error, /ECONNREFUSED/);
+  assert.doesNotMatch(res.body.error, /6379/);
+});

--- a/src/production/hmi/ui/tests/notifications.test.mjs
+++ b/src/production/hmi/ui/tests/notifications.test.mjs
@@ -1,0 +1,155 @@
+"use strict";
+
+/**
+ * FR-D2 regression tests for the admin notification feed.
+ *
+ * These import the real services/notifications.js rather than restating its
+ * logic. The shaping and the read/deleted join were deliberately kept out of
+ * server.js so they could be exercised here without Mongo or a running server.
+ *
+ * The browser side (safe DOM rendering, badge) is covered separately: see the
+ * PR description for the XSS payload check against the live stack, which is a
+ * stronger check than a shimmed DOM would give.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import notificationFeed from "../services/notifications.js";
+
+const { buildFeed, applyState } = notificationFeed;
+
+const donation = (overrides = {}) => ({
+  _id: "d1",
+  created: 1743705600,
+  billing_details: { email: "john@icloud.com" },
+  ...overrides
+});
+
+const user = (overrides = {}) => ({
+  _id: "u1",
+  email: "someone@example.com",
+  createdAt: "2026-08-01T00:00:00.000Z",
+  ...overrides
+});
+
+test("buildFeed derives ids from the source record so state survives a reload", () => {
+  const feed = buildFeed({ donations: [donation()], users: [user()] });
+
+  assert.deepEqual(
+    feed.map(item => item.id),
+    ["donation:d1", "user:u1"]
+  );
+});
+
+test("buildFeed reads the donor email out of billing_details", () => {
+  const [item] = buildFeed({ donations: [donation()] });
+
+  assert.equal(item.message, "New donation received from john@icloud.com");
+  assert.equal(item.type, "donation");
+});
+
+test("buildFeed falls back when a donation has no email attached", () => {
+  const [item] = buildFeed({ donations: [donation({ billing_details: {} })] });
+
+  assert.equal(item.message, "New donation received from an anonymous supporter");
+});
+
+test("buildFeed converts the Stripe seconds timestamp to milliseconds", () => {
+  const [item] = buildFeed({ donations: [donation({ created: 1743705600 })] });
+
+  assert.equal(item.date.getTime(), 1743705600 * 1000);
+});
+
+test("buildFeed falls back to the username when a user has no email", () => {
+  const [item] = buildFeed({ users: [user({ email: undefined, username: "jdoe" })] });
+
+  assert.equal(item.message, "New user registration: jdoe");
+});
+
+test("buildFeed copes with neither email nor username", () => {
+  const [item] = buildFeed({ users: [user({ email: undefined, username: undefined })] });
+
+  assert.equal(item.message, "New user registration: unknown account");
+});
+
+test("buildFeed returns an empty feed rather than throwing when given nothing", () => {
+  assert.deepEqual(buildFeed(), []);
+  assert.deepEqual(buildFeed({}), []);
+});
+
+test("applyState marks an entry read when a stored row says so", () => {
+  const feed = buildFeed({ donations: [donation()] });
+  const { notifications } = applyState(feed, [{ _id: "donation:d1", read: true }]);
+
+  assert.equal(notifications[0].read, true);
+});
+
+test("applyState treats anything with no stored row as unread", () => {
+  const feed = buildFeed({ donations: [donation()] });
+  const { notifications } = applyState(feed, []);
+
+  assert.equal(notifications[0].read, false);
+});
+
+test("applyState drops deleted entries entirely rather than flagging them", () => {
+  const feed = buildFeed({ donations: [donation({ _id: "d1" }), donation({ _id: "d2" })] });
+  const { notifications } = applyState(feed, [{ _id: "donation:d1", deleted: true }]);
+
+  assert.deepEqual(notifications.map(item => item.id), ["donation:d2"]);
+});
+
+test("a deleted entry is not counted as unread", () => {
+  const feed = buildFeed({ donations: [donation({ _id: "d1" }), donation({ _id: "d2" })] });
+  const { unreadCount } = applyState(feed, [{ _id: "donation:d1", deleted: true }]);
+
+  assert.equal(unreadCount, 1);
+});
+
+test("unreadCount is derived from the same list it is counting", () => {
+  const feed = buildFeed({
+    donations: [donation({ _id: "d1" }), donation({ _id: "d2" }), donation({ _id: "d3" })]
+  });
+
+  const { notifications, unreadCount } = applyState(feed, [
+    { _id: "donation:d1", read: true },
+    { _id: "donation:d2", deleted: true }
+  ]);
+
+  assert.equal(unreadCount, notifications.filter(item => !item.read).length);
+  assert.equal(unreadCount, 1);
+});
+
+test("marking everything read leaves a zero unread count", () => {
+  const feed = buildFeed({ donations: [donation({ _id: "d1" })], users: [user({ _id: "u1" })] });
+
+  const { unreadCount } = applyState(feed, [
+    { _id: "donation:d1", read: true },
+    { _id: "user:u1", read: true }
+  ]);
+
+  assert.equal(unreadCount, 0);
+});
+
+test("applyState returns newest first", () => {
+  const feed = buildFeed({
+    donations: [
+      donation({ _id: "old", created: 1000 }),
+      donation({ _id: "new", created: 2000 })
+    ]
+  });
+
+  const { notifications } = applyState(feed, []);
+
+  assert.deepEqual(notifications.map(item => item.id), ["donation:new", "donation:old"]);
+});
+
+test("applyState ignores stored rows for records that no longer exist", () => {
+  const feed = buildFeed({ donations: [donation({ _id: "d1" })] });
+  const { notifications, unreadCount } = applyState(feed, [
+    { _id: "donation:long-gone", read: true, deleted: true }
+  ]);
+
+  assert.equal(notifications.length, 1);
+  assert.equal(unreadCount, 1);
+});


### PR DESCRIPTION
FR-D2: Notification Reliability and Safety

## Summary

The admin notification list was a hardcoded array of three dummy entries sitting in `notifications.js`. Marking something read, deleting it, or marking all read only mutated that array, so every action came back undone on the next refresh. The message text was also interpolated into an HTML template string, and the unread badge had nothing valid to render into.

## Acceptance criteria

| Criterion | Where |
|---|---|
| Notifications loaded from or synchronised with a backend source | `/api/notifications` in `server.js`, feed derived from real donation and user records |
| Read, unread, delete and mark-all-read persist after refresh | Flags stored in a `notificationState` collection, verified through a container restart |
| Messages rendered using safe DOM text handling | `notifications.js` rebuilt on `createElement` / `textContent`, no HTML strings |
| Unread badge stays synchronised with the list | Both drawn in one render pass from the same response, and the badge element fixed |

## Backend

New routes in `server.js`:

- `GET /api/notifications`
- `PATCH /api/notifications/read-all`
- `PATCH /api/notifications/:id/read`
- `DELETE /api/notifications/read`
- `DELETE /api/notifications/:id`

Every action returns the refreshed list, so the browser never keeps a second copy of the state to keep in step by hand.

The feed is built from records we already hold, donations and user registrations, rather than invented data. Ids are derived from the source document (`donation:<id>`, `user:<id>`) rather than generated, otherwise the read state would not line up with the same notification on the next request and everything would look unread again after a reload.

Read and deleted flags live in their own `notificationState` collection, which keeps us from writing UI flags onto the donation and account documents.

Feed shaping and the state join were kept out of `server.js` and put in `services/notifications.js`, so they can be tested without Mongo or a running server.

`DELETE /api/notifications/read` is declared before `DELETE /api/notifications/:id`, otherwise "read" gets swallowed as an id.

## Safe rendering

`notifications.js` no longer builds any element from an HTML string. Notification text is drawn from donation and account records, which makes it effectively user supplied, so a crafted email address dropped into `innerHTML` would have run script in the admin console. Everything is created with the DOM API and written in with `textContent`.

The icon is now chosen from the notification type against a fixed list in the file rather than taken from the response, so nothing outside `notifications.js` decides what class lands on an element.

## Unread badge

The badge was `<class id="notification-badge">`. There is no such element, so there was nothing for the count to render into. It is now a `span`, styled alongside the header component so it looks the same on every admin page that includes the header.

The list and the badge are drawn in a single render pass from the same server response, so they cannot disagree. The previous code updated them from four separate places and leaned on a 100ms `setTimeout` to catch the header finishing loading.

The header is injected after this script runs, so the badge is painted when a `MutationObserver` sees it arrive. The observer disconnects at that point on purpose: the badge sits inside `#header`, so leaving it connected means the badge write counts as a mutation and re-triggers the render in a loop.

## Testing

`npm test` is 32 passing, 17 of them new in `tests/notifications.test.mjs`, covering feed shaping, id derivation, the read and deleted join, sorting, and that the unread count is derived from the same list it is counting.

Verified against the live docker-compose stack:

- 12 notifications built from the real donation and user records
- mark read, delete, mark all read and delete read each persisted across separate requests **and a full container restart**, so the state is genuinely in Mongo
- through the UI: marking one read took the badge from 12 to 11 and matched the list exactly, and survived a page refresh
- mark all read left the badge empty and hidden, and delete read showed the empty state

Safe rendering was checked with a real payload rather than a shimmed DOM. Passing `<img src=x onerror=...><script>...</script>` as a notification message through the real `buildNotificationItem` and attaching the result to the page produced:

- no script execution
- zero `img` and zero `script` elements created
- `textContent` equal to the raw payload, and `innerHTML` beginning `&lt;img`
- the message as a text node

Any notification state created while testing was cleared afterwards.

## Worth a look

`/api/notifications` is not behind `checkUserSession`, matching `/donations` and `/cumulativeDonations` which are already open. I did not add the existing middleware to it because it answers with a redirect to `/login`, which is wrong for an API: axios follows the redirect and the caller ends up parsing the login page as JSON, which is the same failure that was fixed in the sign-in route in #946.

Flagging it rather than fixing it here because authorisation is not in the acceptance criteria for this ticket, and because the session check reads a single shared `JWT` key from Redis rather than a per-user session, so a guard on this endpoint would not mean much until that changes. Happy to pick it up as its own piece of work if you would rather it were handled now.