### PR TITLE
Fix CI: bump Engine.test.Dockerfile off EOL Debian bullseye to bookworm

### DIFF
--- a/src/production/engine/Engine.test.Dockerfile
+++ b/src/production/engine/Engine.test.Dockerfile
@@ -1,5 +1,8 @@
 # Builder (Compilers and heavy lifting)
-ARG BASE_IMAGE=python:3.10-slim-bullseye
+# bullseye (Debian 11) reached full end-of-life 2026-08-31; its apt archive
+# is being frozen/migrated, which breaks package installs unpredictably.
+# bookworm (Debian 12) is the current supported release.
+ARG BASE_IMAGE=python:3.10-slim-bookworm
 FROM ${BASE_IMAGE} AS echo_engine_builder
 
 WORKDIR /build
@@ -39,18 +42,25 @@ WORKDIR /app
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-	libopenexr25 \
+	libopenexr-3-1-30 \
 	libgl1-mesa-glx \
 	libglib2.0-0 \
 	curl \
-	gnupg \
 	ca-certificates \
-	&& echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
-	&& curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
-	&& apt-get update -y \
-	&& apt-get install -y google-cloud-cli \
 	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/* 
+	&& rm -rf /var/lib/apt/lists/*
+
+# Google Cloud CLI, installed from Google's own tarball rather than through
+# apt/apt-key + Google's apt repo. This avoids pulling in gnupg/gnupg2 as an
+# apt dependency purely to verify the repo signature - the previous approach
+# broke when Debian's bullseye-security archive started rejecting that
+# dependency chain around bullseye's 2026-08-31 end-of-life.
+RUN curl -sSL -o /tmp/gcloud.tar.gz \
+		https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz \
+	&& tar -xzf /tmp/gcloud.tar.gz -C /usr/local \
+	&& rm /tmp/gcloud.tar.gz \
+	&& /usr/local/google-cloud-sdk/install.sh --quiet --path-update false --usage-reporting false
+ENV PATH="/usr/local/google-cloud-sdk/bin:$PATH"
 
 COPY --from=echo_engine_builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"


### PR DESCRIPTION
Engine.test.Dockerfile was pinned to python:3.10-slim-bullseye (Debian 11), which reached full end-of-life on 2026-08-31. Its apt archive is being frozen/migrated, causing apt-get install to intermittently 404 on packages that are still listed in a freshly-updated index - specifically gnupg2/gpgsm, pulled in as a dependency of plain gnupg, which broke the combined base-libs + Google Cloud CLI install step in CI's "Docker Image CI" workflow.

Bump the base image to python:3.10-slim-bookworm (Debian 12, currently supported), and switch the Google Cloud CLI install from apt/apt-key to Google's own tarball, removing the gnupg/apt-key dependency chain that was actually failing rather than working around it.

Also renames libopenexr25 -> libopenexr-3-1-30, since bookworm ships OpenEXR 3.x under a different package name.

Verified locally with the same flags CI uses (--no-cache --force-rm, fresh pull from live mirrors): image builds clean, `gcloud --version` works, and tensorflow/opencv/pymongo/paho-mqtt/librosa all still import correctly inside the container after the base image bump.