### PR TITLE
B3.1: Add cursor pagination for GET /detections/cursor

### DIFF
--- a/src/production/backend/app/detections.py
+++ b/src/production/backend/app/detections.py
@@ -1,6 +1,7 @@
-from typing import List, Optional, Dict, Any
+import base64
+import json
+from typing import List, Optional, Dict, Any, Tuple
 from datetime import datetime
-from fastapi import HTTPException
 
 from bson import ObjectId
 from pymongo import ReturnDocument
@@ -8,10 +9,62 @@ from pymongo import ReturnDocument
 from app.database import Detections
 from app.schemas import DetectionCreate, Detection
 
+
 def _doc_to_detection(doc: Dict[str, Any]) -> Optional[Detection]:
     if not doc:
         return None
     return Detection(**doc)
+
+
+def _build_detection_query(
+    species: Optional[str] = None,
+    start_time: Optional[datetime] = None,
+    end_time: Optional[datetime] = None,
+    lat: Optional[float] = None,
+    lon: Optional[float] = None,
+    radius_km: Optional[float] = None,
+) -> Dict[str, Any]:
+    query: Dict[str, Any] = {}
+
+    if species:
+        query["species"] = species
+
+    if start_time or end_time:
+        ts_filter: Dict[str, Any] = {}
+        if start_time:
+            ts_filter["$gte"] = start_time
+        if end_time:
+            ts_filter["$lte"] = end_time
+        query["timestamp"] = ts_filter
+
+    if lat is not None and lon is not None and radius_km is not None:
+        delta_deg = radius_km / 111.0
+        lat_min = lat - delta_deg
+        lat_max = lat + delta_deg
+        lon_min = lon - delta_deg
+        lon_max = lon + delta_deg
+
+        query["microphoneLLA.0"] = {"$gte": lat_min, "$lte": lat_max}
+        query["microphoneLLA.1"] = {"$gte": lon_min, "$lte": lon_max}
+
+    return query
+
+
+def _encode_cursor(timestamp: datetime, detection_id: ObjectId) -> str:
+    payload = {"ts": timestamp.isoformat(), "id": str(detection_id)}
+    return base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+
+
+def _decode_cursor(cursor: str) -> Tuple[datetime, ObjectId]:
+    try:
+        decoded = base64.urlsafe_b64decode(cursor.encode()).decode()
+        payload = json.loads(decoded)
+        cursor_ts = datetime.fromisoformat(payload["ts"])
+        cursor_id = ObjectId(payload["id"])
+    except (KeyError, ValueError, TypeError):
+        raise ValueError("Invalid cursor")
+
+    return cursor_ts, cursor_id
 
 
 def create_detection(detection_in: DetectionCreate) -> Detection:
@@ -46,28 +99,14 @@ def list_detections(
     page: int = 1,
     page_size: int = 20,
 ) -> Dict[str, Any]:
-    query: Dict[str, Any] = {}
-
-    if species:
-        query["species"] = species
-
-    if start_time or end_time:
-        ts_filter: Dict[str, Any] = {}
-        if start_time:
-            ts_filter["$gte"] = start_time
-        if end_time:
-            ts_filter["$lte"] = end_time
-        query["timestamp"] = ts_filter
-
-    if lat is not None and lon is not None and radius_km is not None:
-        delta_deg = radius_km / 111.0
-        lat_min = lat - delta_deg
-        lat_max = lat + delta_deg
-        lon_min = lon - delta_deg
-        lon_max = lon + delta_deg
-
-        query["microphoneLLA.0"] = {"$gte": lat_min, "$lte": lat_max}
-        query["microphoneLLA.1"] = {"$gte": lon_min, "$lte": lon_max}
+    query = _build_detection_query(
+        species=species,
+        start_time=start_time,
+        end_time=end_time,
+        lat=lat,
+        lon=lon,
+        radius_km=radius_km,
+    )
 
     if page < 1:
         page = 1
@@ -93,6 +132,61 @@ def list_detections(
         "page_size": page_size,
     }
 
+
+def list_detections_cursor(
+    species: Optional[str] = None,
+    start_time: Optional[datetime] = None,
+    end_time: Optional[datetime] = None,
+    lat: Optional[float] = None,
+    lon: Optional[float] = None,
+    radius_km: Optional[float] = None,
+    limit: int = 20,
+    cursor: Optional[str] = None,
+) -> Dict[str, Any]:
+    if limit < 1:
+        limit = 20
+
+    query = _build_detection_query(
+        species=species,
+        start_time=start_time,
+        end_time=end_time,
+        lat=lat,
+        lon=lon,
+        radius_km=radius_km,
+    )
+
+    if cursor:
+        cursor_ts, cursor_id = _decode_cursor(cursor)
+        cursor_condition = {
+            "$or": [
+                {"timestamp": {"$lt": cursor_ts}},
+                {"timestamp": cursor_ts, "_id": {"$lt": cursor_id}},
+            ]
+        }
+        if query:
+            query = {"$and": [query, cursor_condition]}
+        else:
+            query = cursor_condition
+
+    docs = list(
+        Detections.find(query)
+        .sort([("timestamp", -1), ("_id", -1)])
+        .limit(limit + 1)
+    )
+
+    next_cursor = None
+    if len(docs) > limit:
+        last_seen = docs[limit - 1]
+        next_cursor = _encode_cursor(last_seen["timestamp"], last_seen["_id"])
+        docs = docs[:limit]
+
+    items: List[Detection] = [Detection(**doc) for doc in docs]
+
+    return {
+        "items": items,
+        "limit": limit,
+        "next_cursor": next_cursor,
+    }
 
 
 def delete_detection(detection_id: str) -> bool:

--- a/src/production/backend/app/routers/detections.py
+++ b/src/production/backend/app/routers/detections.py
@@ -3,7 +3,7 @@ from typing import Optional, Dict, Any
 
 from fastapi import APIRouter, Query, Path, Body, HTTPException, Depends
 
-from app.schemas import Detection, DetectionCreate, DetectionListResponses
+from app.schemas import Detection, DetectionCreate, DetectionListResponses, DetectionCursorListResponse
 from app import detections as detections_service
 from app.middleware.pause_guard import pause_guard
 from app.services.budget import enforce_and_consume
@@ -56,6 +56,43 @@ def list_detections_endpoint(
         page=page,
         page_size=page_size,
     )
+
+
+@router.get(
+    "/cursor",
+    response_model=DetectionCursorListResponse,
+    summary="List detections with cursor pagination",
+    dependencies=[Depends(pause_guard("detections"))],
+)
+def list_detections_cursor_endpoint(
+    species: Optional[str] = Query(None, description="Filter by species name (exact match)"),
+    start_time: Optional[datetime] = Query(
+        None, description="Filter detections from this timestamp (inclusive, ISO 8601)"
+    ),
+    end_time: Optional[datetime] = Query(
+        None, description="Filter detections up to this timestamp (inclusive, ISO 8601)"
+    ),
+    lat: Optional[float] = Query(None, description="Latitude for location filter (requires lon & radius_km)"),
+    lon: Optional[float] = Query(None, description="Longitude for location filter (requires lat & radius_km)"),
+    radius_km: Optional[float] = Query(None, description="Radius in kilometres for location filter (requires lat & lon)"),
+    limit: int = Query(20, ge=1, le=100, description="Number of detections per page (max 100)"),
+    cursor: Optional[str] = Query(None, description="Opaque cursor from a previous cursor response"),
+):
+    enforce_and_consume("detections", cost=1)
+
+    try:
+        return detections_service.list_detections_cursor(
+            species=species,
+            start_time=start_time,
+            end_time=end_time,
+            lat=lat,
+            lon=lon,
+            radius_km=radius_km,
+            limit=limit,
+            cursor=cursor,
+        )
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid cursor")
 
 
 @router.get(

--- a/src/production/backend/app/schemas.py
+++ b/src/production/backend/app/schemas.py
@@ -400,6 +400,17 @@ class DetectionListResponses(BaseModel):
         arbitrary_types_allowed = True
         json_encoders = {ObjectId: str}
 
+
+class DetectionCursorListResponse(BaseModel):
+    items: List[Detection]
+    limit: int
+    next_cursor: Optional[str] = None
+
+    class Config:
+        allow_population_by_field_name = True
+        arbitrary_types_allowed = True
+        json_encoders = {ObjectId: str}
+
 class BudgetRule(BaseModel):
     service: str = Field(..., min_length=1)
     monthly_limit: int = Field(..., ge=0)

--- a/src/production/backend/backend/project-echo-openapi.json
+++ b/src/production/backend/backend/project-echo-openapi.json
@@ -2817,6 +2817,132 @@
         }
       }
     },
+    "/detections/cursor": {
+      "get": {
+        "tags": [
+          "detections"
+        ],
+        "summary": "List detections with cursor pagination",
+        "operationId": "list_detections_cursor_endpoint_detections_cursor_get",
+        "parameters": [
+          {
+            "description": "Filter by species name (exact match)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Species",
+              "description": "Filter by species name (exact match)"
+            },
+            "name": "species",
+            "in": "query"
+          },
+          {
+            "description": "Filter detections from this timestamp (inclusive, ISO 8601)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Start Time",
+              "description": "Filter detections from this timestamp (inclusive, ISO 8601)"
+            },
+            "name": "start_time",
+            "in": "query"
+          },
+          {
+            "description": "Filter detections up to this timestamp (inclusive, ISO 8601)",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "title": "End Time",
+              "description": "Filter detections up to this timestamp (inclusive, ISO 8601)"
+            },
+            "name": "end_time",
+            "in": "query"
+          },
+          {
+            "description": "Latitude for location filter (requires lon & radius_km)",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "title": "Lat",
+              "description": "Latitude for location filter (requires lon & radius_km)"
+            },
+            "name": "lat",
+            "in": "query"
+          },
+          {
+            "description": "Longitude for location filter (requires lat & radius_km)",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "title": "Lon",
+              "description": "Longitude for location filter (requires lat & radius_km)"
+            },
+            "name": "lon",
+            "in": "query"
+          },
+          {
+            "description": "Radius in kilometres for location filter (requires lat & lon)",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "title": "Radius Km",
+              "description": "Radius in kilometres for location filter (requires lat & lon)"
+            },
+            "name": "radius_km",
+            "in": "query"
+          },
+          {
+            "description": "Number of detections per page (max 100)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100.0,
+              "minimum": 1.0,
+              "title": "Limit",
+              "description": "Number of detections per page (max 100)",
+              "default": 20
+            },
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "description": "Opaque cursor from a previous cursor response",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Cursor",
+              "description": "Opaque cursor from a previous cursor response"
+            },
+            "name": "cursor",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DetectionCursorListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/detections/{detection_id}": {
       "get": {
         "tags": [
@@ -3289,6 +3415,31 @@
           "confidence": 99.4,
           "sampleRate": 48000
         }
+      },
+      "DetectionCursorListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/Detection"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "next_cursor": {
+            "type": "string",
+            "title": "Next Cursor"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "limit"
+        ],
+        "title": "DetectionCursorListResponse"
       },
       "DetectionListResponses": {
         "properties": {


### PR DESCRIPTION
## Summary
- Add `GET /detections/cursor` with keyset pagination using `timestamp` + `_id`.
- Return `items`, `limit`, and `next_cursor` while keeping existing `page`/`page_size` list behaviour unchanged.
- Reject malformed cursors with HTTP 400.

## Test plan
- [ ] Seed 25+ detections via `POST /detections`
- [ ] `GET /detections/cursor?limit=10` returns 10 items and a `next_cursor`
- [ ] Paste `next_cursor` for page 2 and confirm no duplicate `_id`s
- [ ] Walk pages until `next_cursor` is null
- [ ] `GET /detections?page=1&page_size=10` still returns page fields
- [ ] `GET /detections/cursor?cursor=not-valid` returns 400
