### PR TITLE
B1.2: Stream detections after MongoDB persistence

### DIFF
--- a/src/production/backend/app/main.py
+++ b/src/production/backend/app/main.py
@@ -97,6 +97,7 @@ print(f" database names: {client.list_database_names()}")
 app.include_router(iot.router, tags=['iot'], prefix='/iot')
 app.include_router(sensors.router, tags=['sensors'], prefix='/sensors')
 app.include_router(payments.router)
+app.include_router(live.router, tags=["live"])
 app.include_router(species_predictor.router, tags=["predict"])
 
 

--- a/src/production/backend/app/routers/engine.py
+++ b/src/production/backend/app/routers/engine.py
@@ -3,7 +3,10 @@ from fastapi import status, APIRouter
 from app import serializers
 from app import schemas
 from app.database import Events
+from app.services.detection_stream import detection_stream_manager
+import asyncio
 import datetime
+import logging
 from app import serializers
 from app import schemas
 from app.database import Events, Species
@@ -12,16 +15,60 @@ from fastapi.responses import StreamingResponse
 import pandas as pd
 
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
-@router.post("/event", status_code=status.HTTP_201_CREATED)
-def create_event(event: schemas.EventSchema):
 
-    result = Events.insert_one(event.dict())
+def _build_created_event(inserted_id):
     pipeline = [
-            {'$match': {'_id': result.inserted_id}},
-        ]
-    new_post = serializers.eventListEntity(Events.aggregate(pipeline))[0]
+        {"$match": {"_id": inserted_id}},
+    ]
+    return serializers.eventListEntity(Events.aggregate(pipeline))[0]
+
+
+def _build_stream_payload(inserted_id):
+    stream_pipeline = [
+        {"$match": {"_id": inserted_id}},
+        {
+            "$lookup": {
+                "from": "species",
+                "localField": "species",
+                "foreignField": "_id",
+                "as": "info",
+            }
+        },
+        {
+            "$replaceRoot": {
+                "newRoot": {
+                    "$mergeObjects": [{"$arrayElemAt": ["$info", 0]}, "$$ROOT"]
+                }
+            }
+        },
+    ]
+    return serializers.eventSpeciesListEntity(
+        Events.aggregate(stream_pipeline)
+    )[0]
+
+
+@router.post("/event", status_code=status.HTTP_201_CREATED)
+async def create_event(event: schemas.EventSchema):
+    # Keep Mongo work off the event loop so open WebSocket clients stay responsive.
+    result = await asyncio.to_thread(Events.insert_one, event.dict())
+    new_post = await asyncio.to_thread(_build_created_event, result.inserted_id)
+
+    # Persistence already succeeded. Broadcast failures must not turn this into a 500.
+    try:
+        stream_payload = await asyncio.to_thread(
+            _build_stream_payload, result.inserted_id
+        )
+        await detection_stream_manager.broadcast(stream_payload)
+    except Exception:
+        logger.warning(
+            "Event %s persisted but live broadcast failed",
+            result.inserted_id,
+            exc_info=True,
+        )
+
     return new_post
 
     

--- a/src/production/backend/app/routers/live.py
+++ b/src/production/backend/app/routers/live.py
@@ -1,27 +1,47 @@
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
-import asyncio
+from typing import Optional
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect, status
+
+from app.middleware.auth import decodeJWT
+from app.services.detection_stream import detection_stream_manager
 
 router = APIRouter()
+
+
+def _extract_ws_token(websocket: WebSocket) -> Optional[str]:
+    token = websocket.query_params.get("token")
+    if token:
+        return token
+
+    auth_header = websocket.headers.get("authorization")
+    if auth_header and auth_header.lower().startswith("bearer "):
+        return auth_header.split(" ", 1)[1].strip() or None
+
+    return None
+
 
 @router.websocket("/ws")
 async def websocket_test(websocket: WebSocket):
     await websocket.accept()
     try:
         while True:
-            await websocket.send_json({"message": "WebSocket test connection successful!"})
-            await asyncio.sleep(2)
+            await websocket.receive_text()
     except WebSocketDisconnect:
         pass
 
-# --- WebSocket endpoint for real-time detections ---
+
 @router.websocket("/ws/detections")
-async def websocket_endpoint(websocket: WebSocket):
-    await websocket.accept()
+async def detection_stream(websocket: WebSocket):
+    token = _extract_ws_token(websocket)
+    payload = decodeJWT(token) if token else None
+    if not payload:
+        # Reject unauthenticated wildlife location streams before accept.
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        return
+
+    await detection_stream_manager.connect(websocket)
     try:
         while True:
-            #Replace/add actual detection logic 
-            detection = {"message": "This is a test detection. Replace with real data."}
-            await websocket.send_json(detection)
-            await asyncio.sleep(2)
+            await websocket.receive_text()
     except WebSocketDisconnect:
-        pass
+        await detection_stream_manager.disconnect(websocket)

--- a/src/production/backend/app/services/detection_stream.py
+++ b/src/production/backend/app/services/detection_stream.py
@@ -1,0 +1,46 @@
+import asyncio
+from typing import Any, Dict, Set
+
+from fastapi import WebSocket
+from fastapi.encoders import jsonable_encoder
+
+
+class DetectionStreamManager:
+    """Tracks WebSocket clients and broadcasts persisted detections."""
+
+    def __init__(self) -> None:
+        self._connections: Set[WebSocket] = set()
+        self._lock = asyncio.Lock()
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        async with self._lock:
+            self._connections.add(websocket)
+
+    async def disconnect(self, websocket: WebSocket) -> None:
+        async with self._lock:
+            self._connections.discard(websocket)
+
+    async def broadcast(self, detection: Dict[str, Any]) -> None:
+        message = jsonable_encoder(detection)
+        async with self._lock:
+            connections = list(self._connections)
+
+        stale: list[WebSocket] = []
+        for websocket in connections:
+            try:
+                await websocket.send_json(message)
+            except Exception:
+                stale.append(websocket)
+
+        if stale:
+            async with self._lock:
+                for websocket in stale:
+                    self._connections.discard(websocket)
+
+    @property
+    def connection_count(self) -> int:
+        return len(self._connections)
+
+
+detection_stream_manager = DetectionStreamManager()

--- a/src/production/hmi/ui/public/js/HMI.js
+++ b/src/production/hmi/ui/public/js/HMI.js
@@ -38,6 +38,7 @@ import {
   retrieveWeather,
 } from "./routes.js";
 import { addIoTNodesToMap } from "./nodes-overlay.js";
+import { connectDetectionStream } from "./detection_stream_client.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Constants
@@ -645,6 +646,7 @@ export function initialiseHMI(hmiState) {
       await addIoTNodesToMap(hmiState);
 
       queueSimUpdate(hmiState);
+      startDetectionStream(hmiState);
       showToast("Map data loaded successfully", "success");
     })
     .catch((error) => {
@@ -745,16 +747,18 @@ export function convertJSONtoAnimalMovementEvent(hmiState, data) {
 }
 
 export function convertJSONtoAnimalVocalizationEvent(hmiState, data) {
+  const speciesName = (data.species || "unknown").toLowerCase();
+
   return {
     timestamp:                      hmiState.currentTime,
     eventTimestamp:                 data.timestamp,
     eventId:                        data._id,
     speciesIdentificationConfidence:data.confidence,
-    speciesScientificName:          data.species.toLowerCase(),
-    commonName:                     data.commonName.toLowerCase(),
-    animalType:                     data.type.toLowerCase(),
-    animalStatus:                   matchStatus(data.status.toLowerCase()),
-    animalDiet:                     data.diet.toLowerCase(),
+    speciesScientificName:          speciesName,
+    commonName:                     (data.commonName || data.species || "unknown").toLowerCase(),
+    animalType:                     (data.type || "mammal").toLowerCase(),
+    animalStatus:                   matchStatus((data.status || "least concern").toLowerCase()),
+    animalDiet:                     (data.diet || "herbivore").toLowerCase(),
     locationConfidence:             100 - data.animalLLAUncertainty,
     estLat:                         data.animalEstLLA[0],
     estLon:                         data.animalEstLLA[1],
@@ -1495,6 +1499,35 @@ export function MapCloseNav() {
 // ─────────────────────────────────────────────────────────────────────────────
 // Live updates
 // ─────────────────────────────────────────────────────────────────────────────
+
+let disconnectDetectionStream = null;
+
+function startDetectionStream(hmiState) {
+  if (disconnectDetectionStream) return;
+
+  disconnectDetectionStream = connectDetectionStream({
+    onStatus: (status) => console.log("Detection stream:", status),
+    onDetection: (data) => {
+      console.log("[B1.2 WS] map handler received detection:", {
+        _id: data._id,
+        species: data.species,
+        sensorId: data.sensorId,
+        confidence: data.confidence,
+      });
+
+      const alreadySeen = hmiState.vocalizationEvents.some(
+        (event) => event.eventId === data._id
+      );
+      if (alreadySeen) {
+        console.log("[B1.2 WS] duplicate ignored:", data._id);
+        return;
+      }
+
+      updateVocalizationLayerFromLiveData(hmiState, [data]);
+      showToast(`Live detection: ${data.species}`, "success");
+    },
+  });
+}
 
 function updateTruthEvents(hmiState) {
   retrieveTruthEventsInTimeRange(hmiState.currentTime - 5, hmiState.currentTime)

--- a/src/production/hmi/ui/public/js/detection_stream_client.js
+++ b/src/production/hmi/ui/public/js/detection_stream_client.js
@@ -1,0 +1,74 @@
+"use strict";
+
+/**
+ * detection_stream_client.js
+ * Connects the HMI map to the Backend detection WebSocket stream.
+ *
+ * Deploy note: set window.ECHO_API_WS_URL (e.g. wss://api.example.com) in
+ * non-local environments. The localhost fallback is for local Docker only.
+ */
+
+function resolveWsBase() {
+  if (window.ECHO_API_WS_URL) {
+    return window.ECHO_API_WS_URL;
+  }
+
+  // Local Docker default: HMI on :8080, API on :9000
+  if (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1") {
+    return "ws://localhost:9000";
+  }
+
+  // Same-host deploy: derive secure WS from the current page origin
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  return `${protocol}//${window.location.host}`;
+}
+
+function resolveAuthToken() {
+  try {
+    return window.localStorage.getItem("token");
+  } catch (error) {
+    console.error("[B1.2 WS] unable to read auth token", error);
+    return null;
+  }
+}
+
+export function connectDetectionStream({ onDetection, onStatus }) {
+  const token = resolveAuthToken();
+  if (!token) {
+    console.error("[B1.2 WS] missing login token; detection stream not started");
+    onStatus?.("unauthorized");
+    return () => {};
+  }
+
+  const wsBase = resolveWsBase();
+  const wsUrl = `${wsBase}/ws/detections?token=${encodeURIComponent(token)}`;
+  const ws = new WebSocket(wsUrl);
+
+  ws.onopen = () => {
+    console.log("[B1.2 WS] connected to", `${wsBase}/ws/detections`);
+    onStatus?.("connected");
+  };
+  ws.onclose = (event) => {
+    console.log("[B1.2 WS] disconnected", event.code);
+    onStatus?.(event.code === 1008 ? "unauthorized" : "closed");
+  };
+  ws.onerror = () => {
+    console.error("[B1.2 WS] connection error");
+    onStatus?.("error");
+  };
+  ws.onmessage = (event) => {
+    try {
+      const detection = JSON.parse(event.data);
+      console.log("[B1.2 WS] STREAM RECEIVED:", detection);
+      onDetection(detection);
+    } catch (error) {
+      console.error("[B1.2 WS] invalid detection stream payload", error);
+    }
+  };
+
+  return () => {
+    if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+      ws.close();
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- Broadcast enriched event payloads over `/ws/detections` only after `Events.insert_one` succeeds.
- Add `DetectionStreamManager` and register the live WebSocket route in the API.
- Require a valid JWT (`?token=` or `Authorization: Bearer`) before accepting `/ws/detections`.
- Keep Mongo insert/lookup off the event loop via `asyncio.to_thread`, and wrap broadcast in try/except so a stream failure cannot turn a successful persist into a 500.
- Connect the HMI map to live detections via a WebSocket client (uses `localStorage.token`, `window.ECHO_API_WS_URL` for deploy).

## Test plan
- [x] Rebased onto latest `main` (resolved `main.py` conflict: keep both `payments` + `live` routers)
- [x] `/ws/detections` rejects missing/invalid token (WS close 1008)
- [x] `/ws/detections` accepts valid JWT from login `localStorage.token`
- [x] `POST /engine/event` still returns 201 after persist even if broadcast/enrichment fails
- [x] Mongo work in `create_event` runs via `asyncio.to_thread` (non-blocking for open sockets)
- [x] Manual Docker/Swagger/HMI persist-then-stream path previously verified (save -> WS toast/console). Re-run after Docker is up: login HMI first so token exists, then `POST /engine/event`
- [x] Deploy note: set `window.ECHO_API_WS_URL` (e.g. `wss://api.example.com`) outside local Docker; localhost fallback is local-only
