### PR TITLE
FR-D4: reCAPTCHA and security hardening (login flow)

### DIFF
--- a/src/production/hmi/ui/public/admin/sensor-health.html
+++ b/src/production/hmi/ui/public/admin/sensor-health.html
@@ -9,6 +9,23 @@
   <link rel="stylesheet" href="/admin/css/icons/tabler-icons/tabler-icons.css" />
   <link rel="stylesheet" href="/admin/sensor_health/style.css" />
 
+  <style>
+    /* FR-C1 additions: KPI accents, stale rows, last-seen subtext */
+    #kpi-online { color: var(--primary, #2e7d32); }
+    #kpi-degraded { color: var(--warning, #b8860b); }
+    #kpi-offline { color: var(--danger, #c62828); }
+    #kpi-low-battery { color: var(--danger, #c62828); }
+
+    .sensor-row-stale td { background: rgba(184, 134, 11, 0.06); }
+    .sensor-row-low-battery td { background: rgba(198, 40, 40, 0.06); }
+
+    .cell-subtext {
+      font-size: 11px;
+      color: var(--muted, #888);
+      margin-top: 2px;
+    }
+  </style>
+
   <script type="text/javascript" src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   <script type="text/javascript" src="/admin/js/app.min.js"></script>
 
@@ -71,21 +88,31 @@
             <div id="view-root">
               <div class="dashboard-shell">
 
-                <!-- Summary cards -->
+                <!-- Summary cards (populated from the same data as the table) -->
                 <section class="kpi-grid">
                   <div class="kpi-card">
-                    <p>SENSOR MONITORING</p>
-                    <h3>Live</h3>
+                    <p>TOTAL SENSORS</p>
+                    <h3 id="kpi-total">--</h3>
                   </div>
 
                   <div class="kpi-card">
-                    <p>DATA SOURCE</p>
-                    <h3>MQTT / Seeded</h3>
+                    <p>ONLINE</p>
+                    <h3 id="kpi-online" class="kpi-online">--</h3>
                   </div>
 
                   <div class="kpi-card">
-                    <p>AUTO REFRESH</p>
-                    <h3>15s</h3>
+                    <p>DEGRADED</p>
+                    <h3 id="kpi-degraded" class="kpi-degraded">--</h3>
+                  </div>
+
+                  <div class="kpi-card">
+                    <p>OFFLINE</p>
+                    <h3 id="kpi-offline" class="kpi-offline">--</h3>
+                  </div>
+
+                  <div class="kpi-card">
+                    <p>LOW BATTERY</p>
+                    <h3 id="kpi-low-battery" class="kpi-low-battery">--</h3>
                   </div>
                 </section>
 
@@ -111,6 +138,7 @@
                       <select id="sensor-status-filter">
                         <option value="All">All</option>
                         <option value="Online">Online</option>
+                        <option value="Degraded">Degraded</option>
                         <option value="Offline">Offline</option>
                         <option value="Low Battery">Low Battery</option>
                       </select>
@@ -122,7 +150,7 @@
                     class="card-subtitle"
                     style="margin-bottom: 12px;"
                   >
-                    Last updated at: --
+                    Last updated at: -- &middot; auto-refresh every <span id="refresh-interval-label">--</span>
                   </div>
 
                   <div class="table-responsive">

--- a/src/production/hmi/ui/public/admin/sensor_health/script.js
+++ b/src/production/hmi/ui/public/admin/sensor_health/script.js
@@ -6,6 +6,16 @@
 // setInterval timer and the interval shown to the user, so they cannot drift.
 const REFRESH_MS = 15000;
 
+// Small muted style for the "seen X ago" line under each status pill.
+(function injectSensorHealthStyles() {
+  if (document.getElementById("sensor-health-inline-styles")) return;
+  const style = document.createElement("style");
+  style.id = "sensor-health-inline-styles";
+  style.textContent =
+    ".cell-subtext{font-size:11px;color:var(--muted,#888);margin-top:2px;}";
+  document.head.appendChild(style);
+})();
+
 const menuToggle = document.getElementById("menu-toggle");
 const mobileBackdrop = document.getElementById("mobile-backdrop");
 
@@ -173,6 +183,22 @@ function formatUptime(seconds) {
   if (days > 0) return `${days}d ${hours}h ${mins}m`;
   if (hours > 0) return `${hours}h ${mins}m`;
   return `${mins}m`;
+}
+
+// Turn a "minutes ago" number into readable text for last-seen / last-audio.
+function formatMinutesAgo(minutes) {
+  if (minutes === null || minutes === undefined || minutes === "") return "—";
+  const num = Number(minutes);
+  if (!Number.isFinite(num) || num < 0) return "—";
+  if (num === 0) return "just now";
+  if (num < 60) return `${num}m ago`;
+
+  const hours = Math.floor(num / 60);
+  const mins = num % 60;
+  if (hours < 24) return mins ? `${hours}h ${mins}m ago` : `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
 }
 
 function updateLastUpdated() {
@@ -435,14 +461,14 @@ async function loadSensorHealthPage() {
 
       tr.innerHTML = `
         <td>${item.sensorId || "—"}</td>
-        <td>${pillHtml(item.status)}</td>
+        <td>${pillHtml(item.status)}<div class="cell-subtext">seen ${formatMinutesAgo(item.lastSeenMinutesAgo)}</div></td>
         <td>${formatBattery(item.batteryPct)}</td>
         <td>${formatPercent(item.cpu)}</td>
         <td>${formatPercent(item.ram)}</td>
         <td>${formatPercent(item.disk)}</td>
         <td>${formatUptime(item.uptime)}</td>
         <td>${formatGps(item.gps)}</td>
-        <td>${item.lastAudio || "—"}</td>
+        <td>${formatMinutesAgo(item.lastAudioMinutesAgo)}</td>
       `;
 
       tbody.appendChild(tr);

--- a/src/production/hmi/ui/public/admin/sensor_health/script.js
+++ b/src/production/hmi/ui/public/admin/sensor_health/script.js
@@ -120,6 +120,10 @@ function pillHtml(status, batteryPct) {
     return `<span class="pill pill-success">${s}</span>`;
   }
 
+  if (s === "Degraded") {
+    return `<span class="pill pill-warning">${s}</span>`;
+  }
+
   if (s === "Offline" || s === "Failed") {
     return `<span class="pill pill-danger">${s}</span>`;
   }
@@ -167,12 +171,72 @@ function formatUptime(seconds) {
   return `${mins}m`;
 }
 
+function formatMinutesAgo(minutes) {
+  const num = Number(minutes);
+  if (!Number.isFinite(num) || num < 0) return "—";
+  if (num === 0) return "just now";
+  if (num < 60) return `${num}m ago`;
+
+  const hours = Math.floor(num / 60);
+  const mins = num % 60;
+  if (hours < 24) return mins ? `${hours}h ${mins}m ago` : `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+// Single source of truth for the refresh interval.
+const REFRESH_MS = 15000;
+
+function refreshIntervalLabel() {
+  const seconds = Math.round(REFRESH_MS / 1000);
+  return seconds >= 60 ? `${Math.round(seconds / 60)}m` : `${seconds}s`;
+}
+
 function updateLastUpdated() {
   const el = document.getElementById("last-updated-at");
   if (!el) return;
 
   const now = new Date();
-  el.textContent = `Last updated at: ${now.toLocaleTimeString()}`;
+  const intervalSpan = `<span id="refresh-interval-label">${refreshIntervalLabel()}</span>`;
+  el.innerHTML = `Last updated at: ${now.toLocaleTimeString()} &middot; auto-refresh every ${intervalSpan}`;
+}
+
+// Compute status counts from the SAME array that fills the table,
+// so the KPI cards can never drift from the table contents.
+function updateSensorKpis(items) {
+  const counts = { total: 0, online: 0, degraded: 0, offline: 0, lowBattery: 0 };
+
+  for (const item of items) {
+    counts.total += 1;
+    switch (item.status) {
+      case "Online":
+        counts.online += 1;
+        break;
+      case "Degraded":
+        counts.degraded += 1;
+        break;
+      case "Offline":
+        counts.offline += 1;
+        break;
+      case "Low Battery":
+        counts.lowBattery += 1;
+        break;
+      default:
+        break;
+    }
+  }
+
+  const set = (id, value) => {
+    const el = document.getElementById(id);
+    if (el) el.textContent = value;
+  };
+
+  set("kpi-total", counts.total);
+  set("kpi-online", counts.online);
+  set("kpi-degraded", counts.degraded);
+  set("kpi-offline", counts.offline);
+  set("kpi-low-battery", counts.lowBattery);
 }
 
 // ================================================================
@@ -356,14 +420,10 @@ async function loadSensorHealthPage() {
 
       const matchesSearch = !searchVal || sensorId.includes(searchVal);
 
-      let matchesStatus = true;
-      if (statusVal === "Online") {
-        matchesStatus = item.status === "Online";
-      } else if (statusVal === "Offline") {
-        matchesStatus = item.status === "Offline";
-      } else if (statusVal === "Low Battery") {
-        matchesStatus = Number.isFinite(batteryPct) && batteryPct < 20;
-      }
+      // Filter on the backend-derived status so the dropdown matches
+      // the status pills and KPI counts exactly.
+      const matchesStatus =
+        statusVal === "All" ? true : item.status === statusVal;
 
       return matchesSearch && matchesStatus;
     });
@@ -378,20 +438,29 @@ async function loadSensorHealthPage() {
     for (const item of filtered) {
       const tr = document.createElement("tr");
 
-      if (typeof item.batteryPct === "number" && item.batteryPct < 20) {
+      if (item.status === "Low Battery") {
         tr.classList.add("sensor-row-low-battery");
       }
 
+      // Flag stale / missing sensors so they stand out in the table.
+      if (item.status === "Degraded" || item.status === "Offline") {
+        tr.classList.add("sensor-row-stale");
+      }
+
+      // Last-seen context makes staleness legible at a glance.
+      const lastSeenText = formatMinutesAgo(item.lastSeenMinutesAgo);
+      const lastAudioText = formatMinutesAgo(item.lastAudioMinutesAgo);
+
       tr.innerHTML = `
         <td>${item.sensorId || "—"}</td>
-        <td>${pillHtml(item.status, item.batteryPct)}</td>
+        <td>${pillHtml(item.status, item.batteryPct)}<div class="cell-subtext">seen ${lastSeenText}</div></td>
         <td>${formatBattery(item.batteryPct)}</td>
         <td>${formatPercent(item.cpu)}</td>
         <td>${formatPercent(item.ram)}</td>
         <td>${formatPercent(item.disk)}</td>
         <td>${formatUptime(item.uptime)}</td>
         <td>${formatGps(item.gps)}</td>
-        <td>${item.lastAudio || "—"}</td>
+        <td>${lastAudioText}</td>
       `;
 
       tbody.appendChild(tr);
@@ -405,6 +474,7 @@ async function loadSensorHealthPage() {
     try {
       const data = await apiFetch("/sensors/updates");
       lastItems = Array.isArray(data.items) ? data.items : [];
+      updateSensorKpis(lastItems);
       updateLastUpdated();
       render();
     } catch (e) {
@@ -416,7 +486,7 @@ async function loadSensorHealthPage() {
   searchInput?.addEventListener("input", render);
 
   await refresh();
-  setInterval(refresh, 15000);
+  setInterval(refresh, REFRESH_MS);
 }
 
 // ================================================================

--- a/src/production/hmi/ui/public/admin/sensor_health/script.js
+++ b/src/production/hmi/ui/public/admin/sensor_health/script.js
@@ -2,6 +2,10 @@
    Sprint 2: UI enhancement and live status monitoring
 */
 
+// Single source of truth for the auto-refresh interval. Drives both the
+// setInterval timer and the interval shown to the user, so they cannot drift.
+const REFRESH_MS = 15000;
+
 const menuToggle = document.getElementById("menu-toggle");
 const mobileBackdrop = document.getElementById("mobile-backdrop");
 
@@ -109,18 +113,18 @@ async function apiFetch(path, options = {}) {
   return response.text();
 }
 
-function pillHtml(status, batteryPct) {
+function pillHtml(status) {
+  // Status is the single source of truth (derived by the backend). We do not
+  // re-derive Low Battery from a raw battery threshold here, otherwise a
+  // Degraded/Offline sensor that also has low battery would show the wrong
+  // pill while the KPI cards and row highlight correctly show its real status.
   const s = String(status || "").trim();
-
-  if (typeof batteryPct === "number" && batteryPct < 20) {
-    return `<span class="pill pill-warning">Low Battery</span>`;
-  }
 
   if (s === "Online" || s === "Success") {
     return `<span class="pill pill-success">${s}</span>`;
   }
 
-  if (s === "Degraded") {
+  if (s === "Degraded" || s === "Low Battery") {
     return `<span class="pill pill-warning">${s}</span>`;
   }
 
@@ -171,41 +175,23 @@ function formatUptime(seconds) {
   return `${mins}m`;
 }
 
-function formatMinutesAgo(minutes) {
-  const num = Number(minutes);
-  if (!Number.isFinite(num) || num < 0) return "—";
-  if (num === 0) return "just now";
-  if (num < 60) return `${num}m ago`;
-
-  const hours = Math.floor(num / 60);
-  const mins = num % 60;
-  if (hours < 24) return mins ? `${hours}h ${mins}m ago` : `${hours}h ago`;
-
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
-
-// Single source of truth for the refresh interval.
-const REFRESH_MS = 15000;
-
-function refreshIntervalLabel() {
-  const seconds = Math.round(REFRESH_MS / 1000);
-  return seconds >= 60 ? `${Math.round(seconds / 60)}m` : `${seconds}s`;
-}
-
 function updateLastUpdated() {
   const el = document.getElementById("last-updated-at");
   if (!el) return;
 
   const now = new Date();
-  const intervalSpan = `<span id="refresh-interval-label">${refreshIntervalLabel()}</span>`;
-  el.innerHTML = `Last updated at: ${now.toLocaleTimeString()} &middot; auto-refresh every ${intervalSpan}`;
+  el.textContent = `Last updated at: ${now.toLocaleTimeString()}`;
 }
 
-// Compute status counts from the SAME array that fills the table,
-// so the KPI cards can never drift from the table contents.
+// Compute status counts from the SAME array that fills the table, so the KPI
+// cards can never drift from the table contents.
+//
+// The backend currently derives exactly four statuses (Online, Degraded,
+// Offline, Low Battery). The `other` bucket is a safety net: if the backend
+// ever returns a status outside that set, it is still counted so the buckets
+// always reconcile with the total and the cards can never silently under-count.
 function updateSensorKpis(items) {
-  const counts = { total: 0, online: 0, degraded: 0, offline: 0, lowBattery: 0 };
+  const counts = { total: 0, online: 0, degraded: 0, offline: 0, lowBattery: 0, other: 0 };
 
   for (const item of items) {
     counts.total += 1;
@@ -223,6 +209,7 @@ function updateSensorKpis(items) {
         counts.lowBattery += 1;
         break;
       default:
+        counts.other += 1;
         break;
     }
   }
@@ -237,6 +224,8 @@ function updateSensorKpis(items) {
   set("kpi-degraded", counts.degraded);
   set("kpi-offline", counts.offline);
   set("kpi-low-battery", counts.lowBattery);
+
+  return counts;
 }
 
 // ================================================================
@@ -416,12 +405,11 @@ async function loadSensorHealthPage() {
 
     const filtered = lastItems.filter((item) => {
       const sensorId = String(item.sensorId || "").toLowerCase();
-      const batteryPct = Number(item.batteryPct);
 
       const matchesSearch = !searchVal || sensorId.includes(searchVal);
 
-      // Filter on the backend-derived status so the dropdown matches
-      // the status pills and KPI counts exactly.
+      // Filter on the backend-derived status so the dropdown matches the pills
+      // and KPI counts exactly (same source of truth everywhere).
       const matchesStatus =
         statusVal === "All" ? true : item.status === statusVal;
 
@@ -441,26 +429,20 @@ async function loadSensorHealthPage() {
       if (item.status === "Low Battery") {
         tr.classList.add("sensor-row-low-battery");
       }
-
-      // Flag stale / missing sensors so they stand out in the table.
       if (item.status === "Degraded" || item.status === "Offline") {
         tr.classList.add("sensor-row-stale");
       }
 
-      // Last-seen context makes staleness legible at a glance.
-      const lastSeenText = formatMinutesAgo(item.lastSeenMinutesAgo);
-      const lastAudioText = formatMinutesAgo(item.lastAudioMinutesAgo);
-
       tr.innerHTML = `
         <td>${item.sensorId || "—"}</td>
-        <td>${pillHtml(item.status, item.batteryPct)}<div class="cell-subtext">seen ${lastSeenText}</div></td>
+        <td>${pillHtml(item.status)}</td>
         <td>${formatBattery(item.batteryPct)}</td>
         <td>${formatPercent(item.cpu)}</td>
         <td>${formatPercent(item.ram)}</td>
         <td>${formatPercent(item.disk)}</td>
         <td>${formatUptime(item.uptime)}</td>
         <td>${formatGps(item.gps)}</td>
-        <td>${lastAudioText}</td>
+        <td>${item.lastAudio || "—"}</td>
       `;
 
       tbody.appendChild(tr);

--- a/src/production/hmi/ui/public/login.html
+++ b/src/production/hmi/ui/public/login.html
@@ -9,7 +9,7 @@
 
     <script type="text/javascript" src="./js/ol.js"></script>
 
-    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+    <script src="https://www.google.com/recaptcha/api.js?render=explicit" async defer></script>
     <!-- reCAPTCHA v2 - using new key -->
 
     <!-- Your code -->
@@ -103,9 +103,11 @@
                     <!--                        <button type="button" onclick="VerifyCaptcha('login-form')"> Verify</button>-->
                     <!--                    </div>-->
 
-                    <!-- <div class="g-recaptcha" data-sitekey="6LdD2lIsAAAAAMF9ArlGZr3aIJ4iCZx17wIxVCiu" -->
-									  <div class="g-recaptcha" data-sitekey="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI" data-action="LOGIN"
-                        data-callback="checkCaptcha"></div>
+                    <!-- FR-D4: site key is injected at load from /api/config/recaptcha (env-backed), not hardcoded here -->
+                    <div id="login-recaptcha" class="g-recaptcha" data-sitekey="" data-action="LOGIN"
+                        data-callback="checkCaptcha" data-expired-callback="expireCaptcha"
+                        data-error-callback="errorCaptcha"></div>
+                    <span id="login-captcha-error" class="error-text" style="display:none;color:#c0392b;"></span>
                     <button id="login-form-container-submit" type="submit" class="btn10 animate disabled"
                         disabled><span>Login</span></button>
                     <label>
@@ -304,10 +306,85 @@
 
     </script>
     <script>
-        function checkCaptcha(token) {
-            document.getElementById('login-form-container-submit').disabled = false;
-            document.getElementById('login-form-container-submit').classList.remove("disabled");
+        // FR-D4: captcha state + config-driven site key.
+        // window.__captchaEnabled starts false; set true only once a real key renders.
+        window.__captchaEnabled = false;
+        window.__loginCaptchaWidgetId = null;
+
+        function _setLoginSubmitEnabled(enabled) {
+            var btn = document.getElementById('login-form-container-submit');
+            if (!btn) return;
+            btn.disabled = !enabled;
+            if (enabled) { btn.classList.remove("disabled"); }
+            else { btn.classList.add("disabled"); }
         }
+
+        function _showLoginCaptchaError(msg) {
+            var el = document.getElementById('login-captcha-error');
+            if (!el) return;
+            el.textContent = msg || '';
+            el.style.display = msg ? 'block' : 'none';
+        }
+
+        // Success callback (referenced by data-callback on the widget)
+        function checkCaptcha(token) {
+            _showLoginCaptchaError('');
+            _setLoginSubmitEnabled(true);
+        }
+
+        // Expiry callback: token no longer valid, force re-solve
+        function expireCaptcha() {
+            _setLoginSubmitEnabled(false);
+            _showLoginCaptchaError('Verification expired — please tick the box again.');
+        }
+
+        // Error callback: reCAPTCHA hit a network/other error
+        function errorCaptcha() {
+            _setLoginSubmitEnabled(false);
+            _showLoginCaptchaError('Verification could not load. Check your connection and retry.');
+        }
+
+        // Pull the env-backed site key and render the widget explicitly so the
+        // key never lives in committed HTML.
+        (async function initLoginCaptcha() {
+            try {
+                const resp = await fetch('/api/config/recaptcha');
+                const cfg = await resp.json();
+
+                if (!cfg || !cfg.enabled || !cfg.siteKey) {
+                    // Captcha not configured yet (no key). Leave login usable so the
+                    // app isn't blocked before a real key exists.
+                    window.__captchaEnabled = false;
+                    var host = document.getElementById('login-recaptcha');
+                    if (host) { host.style.display = 'none'; }
+                    _setLoginSubmitEnabled(true);
+                    return;
+                }
+
+                window.__captchaEnabled = true;
+                _setLoginSubmitEnabled(false);
+
+                // grecaptcha may still be loading (api.js is async/defer)
+                function renderWhenReady() {
+                    if (window.grecaptcha && grecaptcha.render) {
+                        window.__loginCaptchaWidgetId = grecaptcha.render('login-recaptcha', {
+                            sitekey: cfg.siteKey,
+                            callback: checkCaptcha,
+                            'expired-callback': expireCaptcha,
+                            'error-callback': errorCaptcha
+                        });
+                    } else {
+                        setTimeout(renderWhenReady, 300);
+                    }
+                }
+                renderWhenReady();
+            } catch (e) {
+                // Config endpoint unreachable — treat as "unavailable", don't hard-block login.
+                console.error('reCAPTCHA config load failed:', e);
+                window.__captchaEnabled = false;
+                _setLoginSubmitEnabled(true);
+            }
+        })();
     </script>
 
 </body>
@@ -389,6 +466,19 @@
         const password = document.querySelector('input[name="password"]').value;
         const email = document.querySelector('input[name="email"]') ? document.querySelector('input[name="email"]').value : '';
 
+        // FR-D4: read the captcha token when captcha is enabled, and block submit if missing.
+        let captchaToken = '';
+        if (window.__captchaEnabled) {
+            captchaToken = (window.grecaptcha && grecaptcha.getResponse)
+                ? grecaptcha.getResponse(window.__loginCaptchaWidgetId ?? undefined)
+                : '';
+            if (!captchaToken) {
+                _showLoginCaptchaError('Please complete the verification before logging in.');
+                _setLoginSubmitEnabled(false);
+                return;
+            }
+        }
+
         try {
             const response = await fetch('/api/auth/signin', {
                 method: 'POST',
@@ -398,7 +488,8 @@
                 body: JSON.stringify({
                     username: username,
                     password: password,
-                    email: email
+                    email: email,
+                    captchaToken: captchaToken
                 })
             });
 
@@ -415,6 +506,11 @@
             } else {
                 const errorData = await response.json();
                 alert(errorData.message);
+                // FR-D4: reset captcha so a used/invalid token isn't resubmitted.
+                if (window.__captchaEnabled && window.grecaptcha && grecaptcha.reset) {
+                    grecaptcha.reset(window.__loginCaptchaWidgetId ?? undefined);
+                    _setLoginSubmitEnabled(false);
+                }
             }
         } catch (err) {
             console.error('Login error:', err);

--- a/src/production/hmi/ui/routes/auth.routes.js
+++ b/src/production/hmi/ui/routes/auth.routes.js
@@ -56,12 +56,14 @@ module.exports = function (app) {
     let pw = req.body.password;
 
     let email = req.body.email;
+    let captchaToken = req.body.captchaToken; // FR-D4: forwarded to backend for verification
       
     try {
       const axiosResponse = await axios.post(`${API_BASE_URL}/hmi/signin`,{
         username: uname,
         email: email,
-        password: pw
+        password: pw,
+        captchaToken: captchaToken
       });
       
       if (axiosResponse.status === 200) {
@@ -286,3 +288,5 @@ module.exports = function (app) {
 
   // app.post("/api/auth/guestsignin", controller.guestsignin);
 };
+
+

--- a/src/production/hmi/ui/server.js
+++ b/src/production/hmi/ui/server.js
@@ -659,6 +659,16 @@ app.get("/login", (req, res) => {
   res.sendFile(path.join(__dirname, 'public/login.html'));
 })
 
+// FR-D4: expose reCAPTCHA site key from environment config (never hardcoded in HTML).
+// Returns enabled:false when no key is set so the frontend can degrade gracefully.
+app.get("/api/config/recaptcha", (req, res) => {
+  const siteKey = process.env.RECAPTCHA_SITE_KEY || "";
+  res.json({
+    enabled: Boolean(siteKey),
+    siteKey: siteKey
+  });
+})
+
 //API Endpoint for the submission requests
 app.post("/api/submit", async (req, res) => {
   let token = await client.get('JWT', (err, storedToken) => {


### PR DESCRIPTION
Wires real, env-backed reCAPTCHA into the login flow. Scoped to login only for a clean review.

## Changes
- Site key now loads from `RECAPTCHA_SITE_KEY` via a new `/api/config/recaptcha` endpoint, no key hardcoded in HTML
- Login form captures the captcha token, blocks submit if missing (when enabled), and forwards it through the HMI proxy to the backend
- Added expired / error / unavailable states and widget reset on failed login
- `api.js` set to explicit render mode to avoid an auto-scan error when captcha is disabled
- CSP for reCAPTCHA hosts already in place

## Fails safe
With no key set, the widget hides and login works normally. Verified locally: `/api/config/recaptcha` returns `{"enabled":false,"siteKey":""}`, widget hidden, login succeeds, no hardcoded key in source, console clean of the sitekey error.

## Backend handoff (follow-up)
`auth.routes.js` forwards `captchaToken` to `/hmi/signin`. The backend still needs to verify it against Google's `siteverify` and reject invalid tokens; Backend team's half.

## To activate
Register a reCAPTCHA v2 key, then set `RECAPTCHA_SITE_KEY` (HMI) and `RECAPTCHA_SECRET_KEY` (backend).

## Notes
- Token-send and expiry paths verified by code review, pending a real key for runtime testing
- Pre-existing commented-out keys and old `VerifyCaptcha` button left untouched