### PR TITLE
EE/KF: Standardise Engine integration contracts

### DIFF
--- a/src/production/engine/echo_engine.py
+++ b/src/production/engine/echo_engine.py
@@ -747,6 +747,148 @@ class EchoEngine():
         return base64_message
 
 
+    def _normalise_lla_field(self, value, field_name, allow_null=False):
+        """
+        Convert one LLA field to the standard object shape.
+
+        Accepts a 3-element [lat, lon, alt] array, an already-valid
+        {latitude, longitude, altitude} object, or null when allowed.
+        """
+
+        if value is None:
+            if allow_null:
+                return None
+            raise ValueError(
+                f"Malformed LLA for {field_name}: "
+                "field is required and cannot be null."
+            )
+
+        if isinstance(value, dict):
+            required_keys = ("latitude", "longitude", "altitude")
+            missing_keys = [
+                key for key in required_keys if key not in value
+            ]
+            if missing_keys:
+                raise ValueError(
+                    f"Malformed LLA for {field_name}: "
+                    "expected keys latitude, longitude, altitude. "
+                    f"Missing: {missing_keys}."
+                )
+            try:
+                return {
+                    "latitude": float(value["latitude"]),
+                    "longitude": float(value["longitude"]),
+                    "altitude": float(value["altitude"]),
+                }
+            except (TypeError, ValueError) as error:
+                raise ValueError(
+                    f"Malformed LLA for {field_name}: "
+                    "latitude, longitude and altitude must be numeric."
+                ) from error
+
+        if isinstance(value, (list, tuple)):
+            if len(value) != 3:
+                raise ValueError(
+                    f"Malformed LLA for {field_name}: "
+                    "expected a 3-element array "
+                    "[latitude, longitude, altitude], "
+                    f"got length {len(value)}."
+                )
+            try:
+                return {
+                    "latitude": float(value[0]),
+                    "longitude": float(value[1]),
+                    "altitude": float(value[2]),
+                }
+            except (TypeError, ValueError) as error:
+                raise ValueError(
+                    f"Malformed LLA for {field_name}: "
+                    "array values must be numeric "
+                    "[latitude, longitude, altitude]."
+                ) from error
+
+        raise ValueError(
+            f"Malformed LLA for {field_name}: "
+            "expected an object with latitude, longitude and altitude, "
+            "a 3-element array, or null."
+        )
+
+
+    def _is_legacy_simulator_payload(self, audio_event):
+        """
+        Identify the current Simulator / HMI MQTT shape so sourceType
+        can be defaulted only for those messages.
+        """
+
+        if audio_event.get("audioFile") is not None:
+            return True
+        if audio_event.get("mode") is not None:
+            return True
+
+        for field_name in (
+            "microphoneLLA",
+            "animalEstLLA",
+            "animalTrueLLA",
+        ):
+            if isinstance(audio_event.get(field_name), (list, tuple)):
+                return True
+
+        return False
+
+
+    def normalise_mqtt_audio_event(self, audio_event):
+        """
+        Normalise an MQTT audio event at the Engine input boundary.
+
+        Standard-schema messages are accepted unchanged (aside from
+        numeric LLA coercion). Legacy Simulator 3-element LLA arrays
+        are converted to objects. sourceType is preserved when present
+        and defaulted to "simulator" only for legacy Simulator messages.
+        """
+
+        if not isinstance(audio_event, dict):
+            raise ValueError(
+                "Malformed MQTT payload: expected a JSON object."
+            )
+
+        # Preserve extra legacy fields such as mode and audioFile.
+        normalised = dict(audio_event)
+
+        source_type = normalised.get("sourceType")
+        if source_type in (None, ""):
+            if self._is_legacy_simulator_payload(audio_event):
+                normalised["sourceType"] = "simulator"
+            else:
+                raise ValueError(
+                    "Malformed MQTT payload: sourceType is required "
+                    "for standard messages and must be 'real' or "
+                    "'simulator'."
+                )
+        elif source_type not in ("real", "simulator"):
+            raise ValueError(
+                "Malformed MQTT payload: sourceType must be "
+                f"'real' or 'simulator', got {source_type!r}."
+            )
+
+        normalised["microphoneLLA"] = self._normalise_lla_field(
+            normalised.get("microphoneLLA"),
+            "microphoneLLA",
+            allow_null=False,
+        )
+        normalised["animalEstLLA"] = self._normalise_lla_field(
+            normalised.get("animalEstLLA"),
+            "animalEstLLA",
+            allow_null=True,
+        )
+        normalised["animalTrueLLA"] = self._normalise_lla_field(
+            normalised.get("animalTrueLLA"),
+            "animalTrueLLA",
+            allow_null=True,
+        )
+
+        return normalised
+
+
     ########################################################################################
     ########################################################################################
     def on_subscribe(self, client, userdata, mid, granted_qos):
@@ -759,13 +901,18 @@ class EchoEngine():
         print("Recieved audio message, processing via engine model...")
         try:
             audio_event = json.loads(msg.payload)
+            audio_event = self.normalise_mqtt_audio_event(audio_event)
             print(audio_event['timestamp'])
 
             audio_clip = ""
             image = None
             sample_rate = 0
 
-            if(audio_event['audioFile'] == "Recording_Mode"): # classic model
+            # audioFile is legacy Simulator/HMI routing only.
+            # Standard ESP32/Simulator messages omit it and use EfficientNetV2.
+            audio_file = audio_event.get("audioFile")
+
+            if(audio_file == "Recording_Mode"): # classic model
 
                 print("Recording_Mode - EfficientNetV2 TFLite")
 
@@ -803,7 +950,7 @@ class EchoEngine():
                     predicted_probability
                 )
 
-            elif(audio_event['audioFile'] == "Recording_Mode_V2"):
+            elif(audio_file == "Recording_Mode_V2"):
                 # convert to string representation of audio to binary for processing
                 print("Recording_Mode_V2")
                 sample_rate = 16000
@@ -832,16 +979,22 @@ class EchoEngine():
                     # update the audio event with the re-sampled audio
                     audio_event["audioClip"] = self.audio_to_string(audio_subsection)
 
-                    new_lat = audio_event['animalEstLLA'][0]
-                    new_lon = audio_event['animalEstLLA'][1]
+                    # LLA fields are objects after MQTT input normalisation.
+                    estimated_lla = audio_event['animalEstLLA'] or {}
+                    new_lat = estimated_lla.get("latitude")
+                    new_lon = estimated_lla.get("longitude")
 
                     if(iteration_count > 0):
-                        lat = audio_event['animalEstLLA'][0]
-                        lon = audio_event['animalEstLLA'][1]
+                        lat = estimated_lla.get("latitude")
+                        lon = estimated_lla.get("longitude")
 
                         new_lat, new_lon = self.generate_random_location(lat, lon, 50, 100)
 
-                    new_lla = [new_lat, new_lon, 0.0]
+                    new_lla = {
+                        "latitude": new_lat,
+                        "longitude": new_lon,
+                        "altitude": 0.0,
+                    }
 
                     audio_event['animalEstLLA'] = new_lla
                     audio_event['animalTrueLLA'] = new_lla
@@ -907,17 +1060,29 @@ class EchoEngine():
     ########################################################################################
     def echo_api_send_detection_event(self, audio_event, sample_rate, predicted_class, predicted_probability):
 
+        # Prefer the original MQTT sampleRate when the standard schema
+        # provided one. Legacy Simulator messages omit it, so keep the
+        # inference-derived value used today.
+        if (
+            "sampleRate" in audio_event
+            and audio_event["sampleRate"] is not None
+        ):
+            output_sample_rate = audio_event["sampleRate"]
+        else:
+            output_sample_rate = sample_rate
+
         detection_event = {
+            "sourceType": audio_event["sourceType"],
             "timestamp": audio_event["timestamp"],
+            "sensorId": audio_event["sensorId"],
             "species": predicted_class,
             "confidence": predicted_probability,
-            "sensorId": audio_event["sensorId"],
             "microphoneLLA": audio_event["microphoneLLA"],
             "animalEstLLA": audio_event["animalEstLLA"],
             "animalTrueLLA": audio_event["animalTrueLLA"],
             "animalLLAUncertainty": audio_event["animalLLAUncertainty"],
             "audioClip": audio_event["audioClip"],
-            "sampleRate": sample_rate
+            "sampleRate": output_sample_rate
         }
 
         url = self.config['API_URL']
@@ -1142,8 +1307,13 @@ class EchoEngine():
             print("Edge prediction missing GPS coordinates, skipping.")
             return
 
-        lla = [lat, lon, 0.0]
+        lla = {
+            "latitude": float(lat),
+            "longitude": float(lon),
+            "altitude": 0.0,
+        }
         audio_event = {
+            "sourceType":         payload.get("sourceType", "real"),
             "timestamp":          payload.get("timestamp", str(int(time.time()))),
             "sensorId":           payload.get("sensor_id", "unknown_edge_node"),
             "microphoneLLA":      lla,
@@ -1218,8 +1388,13 @@ class EchoEngine():
             print(f"IoT Predicted probability : {predicted_probability}")
 
             # Build audio_event in the format expected by echo_api_send_detection_event
-            lla = [lat, lon, 0.0]
+            lla = {
+                "latitude": float(lat),
+                "longitude": float(lon),
+                "altitude": 0.0,
+            }
             audio_event = {
+                "sourceType": payload.get("sourceType", "real"),
                 "timestamp": timestamp,
                 "sensorId": sensor_id,
                 "microphoneLLA": lla,

--- a/src/production/engine/test_engine_core.py
+++ b/src/production/engine/test_engine_core.py
@@ -120,9 +120,22 @@ class TestEdgePredictionHandling(unittest.TestCase):
             audio_event["sensorId"],
             "edge-device-01"
         )
+        self.assertEqual(audio_event["sourceType"], "real")
         self.assertEqual(
             audio_event["microphoneLLA"],
-            [-37.8136, 144.9631, 0.0]
+            {
+                "latitude": -37.8136,
+                "longitude": 144.9631,
+                "altitude": 0.0,
+            }
+        )
+        self.assertEqual(
+            audio_event["animalEstLLA"],
+            audio_event["microphoneLLA"]
+        )
+        self.assertEqual(
+            audio_event["animalTrueLLA"],
+            audio_event["microphoneLLA"]
         )
 
     def test_edge_prediction_without_gps_rejected(self):

--- a/src/production/engine/test_engine_input_contract.py
+++ b/src/production/engine/test_engine_input_contract.py
@@ -1,0 +1,315 @@
+"""
+Tests for Engine MQTT input normalisation and standard-schema routing.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from test_iot_integration import EchoEngine, _make_msg
+
+import echo_engine as engine_module
+
+
+STANDARD_LLA = {
+    "latitude": -37.8136,
+    "longitude": 144.9631,
+    "altitude": 10.0,
+}
+
+
+def _standard_esp32_payload(**overrides):
+    payload = {
+        "sourceType": "real",
+        "timestamp": "2026-09-10T10:00:00Z",
+        "sensorId": "esp32-node-01",
+        "microphoneLLA": dict(STANDARD_LLA),
+        "animalEstLLA": None,
+        "animalTrueLLA": None,
+        "animalLLAUncertainty": None,
+        "audioClip": "VGVzdCBhdWRpbw==",
+        "sampleRate": 16000,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _legacy_simulator_payload(**overrides):
+    payload = {
+        "timestamp": "2026-09-10T10:00:00Z",
+        "sensorId": "sensor-001",
+        "microphoneLLA": [-37.8136, 144.9631, 0.0],
+        "animalEstLLA": [-37.8136, 144.9631, 0.0],
+        "animalTrueLLA": [-37.8136, 144.9631, 0.0],
+        "animalLLAUncertainty": 5.0,
+        "audioClip": "VGVzdCBhdWRpbw==",
+        "mode": "Animal_Mode",
+        "audioFile": "kookaburra/sample.wav",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestMqttInputNormalisation(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = EchoEngine()
+
+    def test_standard_schema_accepted_unchanged(self):
+        payload = _standard_esp32_payload()
+        normalised = self.engine.normalise_mqtt_audio_event(payload)
+
+        self.assertEqual(normalised["sourceType"], "real")
+        self.assertEqual(normalised["timestamp"], payload["timestamp"])
+        self.assertEqual(normalised["sensorId"], payload["sensorId"])
+        self.assertEqual(normalised["audioClip"], payload["audioClip"])
+        self.assertEqual(normalised["sampleRate"], 16000)
+        self.assertIsNone(normalised["animalEstLLA"])
+        self.assertIsNone(normalised["animalTrueLLA"])
+        self.assertIsNone(normalised["animalLLAUncertainty"])
+        self.assertEqual(
+            normalised["microphoneLLA"],
+            STANDARD_LLA,
+        )
+        self.assertNotIn("audioFile", normalised)
+        self.assertNotIn("mode", normalised)
+
+    def test_legacy_array_lla_converted_to_objects(self):
+        normalised = self.engine.normalise_mqtt_audio_event(
+            _legacy_simulator_payload()
+        )
+
+        expected_lla = {
+            "latitude": -37.8136,
+            "longitude": 144.9631,
+            "altitude": 0.0,
+        }
+        self.assertEqual(normalised["microphoneLLA"], expected_lla)
+        self.assertEqual(normalised["animalEstLLA"], expected_lla)
+        self.assertEqual(normalised["animalTrueLLA"], expected_lla)
+
+    def test_legacy_simulator_defaults_source_type(self):
+        normalised = self.engine.normalise_mqtt_audio_event(
+            _legacy_simulator_payload()
+        )
+
+        self.assertEqual(normalised["sourceType"], "simulator")
+        self.assertEqual(normalised["mode"], "Animal_Mode")
+        self.assertEqual(
+            normalised["audioFile"],
+            "kookaburra/sample.wav",
+        )
+        self.assertNotIn("sampleRate", normalised)
+
+    def test_provided_source_type_is_preserved_on_legacy_shape(self):
+        normalised = self.engine.normalise_mqtt_audio_event(
+            _legacy_simulator_payload(sourceType="real")
+        )
+
+        self.assertEqual(normalised["sourceType"], "real")
+
+    def test_malformed_lla_array_length_raises_controlled_error(self):
+        payload = _legacy_simulator_payload(
+            microphoneLLA=[-37.8136, 144.9631]
+        )
+
+        with self.assertRaises(ValueError) as raised:
+            self.engine.normalise_mqtt_audio_event(payload)
+
+        self.assertIn("microphoneLLA", str(raised.exception))
+        self.assertIn("Malformed LLA", str(raised.exception))
+
+    def test_malformed_lla_object_missing_keys_raises_controlled_error(self):
+        payload = _standard_esp32_payload(
+            microphoneLLA={"latitude": -37.8136, "longitude": 144.9631}
+        )
+
+        with self.assertRaises(ValueError) as raised:
+            self.engine.normalise_mqtt_audio_event(payload)
+
+        self.assertIn("microphoneLLA", str(raised.exception))
+        self.assertIn("Malformed LLA", str(raised.exception))
+
+    def test_null_microphone_lla_rejected(self):
+        payload = _standard_esp32_payload(microphoneLLA=None)
+
+        with self.assertRaises(ValueError) as raised:
+            self.engine.normalise_mqtt_audio_event(payload)
+
+        self.assertIn("microphoneLLA", str(raised.exception))
+
+
+class TestOnMessageContractRouting(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = EchoEngine()
+        self.engine.string_to_audio = MagicMock(return_value=b"audio")
+        self.engine.efficientnetv2_tflite_predict_from_audio_bytes = (
+            MagicMock(
+                return_value=(
+                    "Magpie",
+                    91.5,
+                    None,
+                    32000,
+                    [],
+                )
+            )
+        )
+        self.engine.echo_api_send_detection_event = MagicMock()
+
+    def test_standard_payload_without_audiofile_uses_efficientnet(self):
+        self.engine.on_message(
+            None,
+            None,
+            _make_msg(_standard_esp32_payload()),
+        )
+
+        self.engine.efficientnetv2_tflite_predict_from_audio_bytes.assert_called_once()
+        self.engine.echo_api_send_detection_event.assert_called_once()
+
+        audio_event = (
+            self.engine.echo_api_send_detection_event.call_args[0][0]
+        )
+        self.assertEqual(audio_event["sourceType"], "real")
+        self.assertEqual(audio_event["sampleRate"], 16000)
+        self.assertEqual(
+            audio_event["microphoneLLA"]["latitude"],
+            -37.8136,
+        )
+        self.assertIsNone(audio_event["animalEstLLA"])
+        self.assertNotIn("audioFile", audio_event)
+
+    def test_legacy_simulator_payload_uses_efficientnet(self):
+        self.engine.on_message(
+            None,
+            None,
+            _make_msg(_legacy_simulator_payload()),
+        )
+
+        self.engine.efficientnetv2_tflite_predict_from_audio_bytes.assert_called_once()
+        audio_event = (
+            self.engine.echo_api_send_detection_event.call_args[0][0]
+        )
+        self.assertEqual(audio_event["sourceType"], "simulator")
+        self.assertEqual(
+            audio_event["audioFile"],
+            "kookaburra/sample.wav",
+        )
+        self.assertEqual(
+            audio_event["microphoneLLA"],
+            {
+                "latitude": -37.8136,
+                "longitude": 144.9631,
+                "altitude": 0.0,
+            },
+        )
+
+    def test_recording_mode_still_uses_efficientnet(self):
+        self.engine.on_message(
+            None,
+            None,
+            _make_msg(
+                _legacy_simulator_payload(
+                    audioFile="Recording_Mode",
+                    mode="Recording_Mode",
+                )
+            ),
+        )
+
+        self.engine.efficientnetv2_tflite_predict_from_audio_bytes.assert_called_once()
+        audio_event = (
+            self.engine.echo_api_send_detection_event.call_args[0][0]
+        )
+        self.assertEqual(audio_event["sourceType"], "simulator")
+        self.assertEqual(audio_event["audioFile"], "Recording_Mode")
+
+    def test_malformed_lla_does_not_call_inference(self):
+        self.engine.on_message(
+            None,
+            None,
+            _make_msg(
+                _legacy_simulator_payload(
+                    microphoneLLA=[-37.8136]
+                )
+            ),
+        )
+
+        self.engine.efficientnetv2_tflite_predict_from_audio_bytes.assert_not_called()
+        self.engine.echo_api_send_detection_event.assert_not_called()
+
+
+class TestOnMessagePostsStandardEvent(unittest.TestCase):
+
+    def setUp(self):
+        self.engine = EchoEngine()
+        self.engine.config["API_URL"] = (
+            "http://mock-backend/engine/event"
+        )
+        self.engine.string_to_audio = MagicMock(return_value=b"audio")
+        self.engine.efficientnetv2_tflite_predict_from_audio_bytes = (
+            MagicMock(
+                return_value=(
+                    "Magpie",
+                    91.5,
+                    None,
+                    32000,
+                    [],
+                )
+            )
+        )
+
+    def test_esp32_sample_rate_and_source_type_reach_backend_payload(self):
+        mock_response = MagicMock()
+        mock_response.text = "accepted"
+
+        with patch.object(
+            engine_module.requests,
+            "post",
+            return_value=mock_response,
+        ) as mock_post:
+            self.engine.on_message(
+                None,
+                None,
+                _make_msg(_standard_esp32_payload()),
+            )
+
+        posted_payload = mock_post.call_args.kwargs["json"]
+        self.assertEqual(posted_payload["sourceType"], "real")
+        self.assertEqual(posted_payload["sampleRate"], 16000)
+        self.assertEqual(posted_payload["species"], "Magpie")
+        self.assertEqual(posted_payload["confidence"], 91.5)
+        self.assertIsNone(posted_payload["animalEstLLA"])
+        self.assertEqual(
+            posted_payload["microphoneLLA"]["longitude"],
+            144.9631,
+        )
+
+    def test_legacy_simulator_uses_inference_sample_rate(self):
+        mock_response = MagicMock()
+        mock_response.text = "accepted"
+
+        with patch.object(
+            engine_module.requests,
+            "post",
+            return_value=mock_response,
+        ) as mock_post:
+            self.engine.on_message(
+                None,
+                None,
+                _make_msg(_legacy_simulator_payload()),
+            )
+
+        posted_payload = mock_post.call_args.kwargs["json"]
+        self.assertEqual(posted_payload["sourceType"], "simulator")
+        self.assertEqual(posted_payload["sampleRate"], 32000)
+        self.assertEqual(
+            posted_payload["animalEstLLA"],
+            {
+                "latitude": -37.8136,
+                "longitude": 144.9631,
+                "altitude": 0.0,
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/production/engine/test_engine_output.py
+++ b/src/production/engine/test_engine_output.py
@@ -19,23 +19,24 @@ class TestEnginePredictionOutput(unittest.TestCase):
         )
 
         self.audio_event = {
+            "sourceType": "simulator",
             "timestamp": "2026-08-06T10:30:00Z",
             "sensorId": "sensor-001",
-            "microphoneLLA": [
-                -37.8136,
-                144.9631,
-                0.0,
-            ],
-            "animalEstLLA": [
-                -37.8136,
-                144.9631,
-                0.0,
-            ],
-            "animalTrueLLA": [
-                -37.8136,
-                144.9631,
-                0.0,
-            ],
+            "microphoneLLA": {
+                "latitude": -37.8136,
+                "longitude": 144.9631,
+                "altitude": 0.0,
+            },
+            "animalEstLLA": {
+                "latitude": -37.8136,
+                "longitude": 144.9631,
+                "altitude": 0.0,
+            },
+            "animalTrueLLA": {
+                "latitude": -37.8136,
+                "longitude": 144.9631,
+                "altitude": 0.0,
+            },
             "animalLLAUncertainty": 5.0,
             "audioClip": "base64-test-audio",
         }
@@ -57,25 +58,26 @@ class TestEnginePredictionOutput(unittest.TestCase):
             )
 
         expected_payload = {
+            "sourceType": "simulator",
             "timestamp": "2026-08-06T10:30:00Z",
             "species": "Magpie",
             "confidence": 91.5,
             "sensorId": "sensor-001",
-            "microphoneLLA": [
-                -37.8136,
-                144.9631,
-                0.0,
-            ],
-            "animalEstLLA": [
-                -37.8136,
-                144.9631,
-                0.0,
-            ],
-            "animalTrueLLA": [
-                -37.8136,
-                144.9631,
-                0.0,
-            ],
+            "microphoneLLA": {
+                "latitude": -37.8136,
+                "longitude": 144.9631,
+                "altitude": 0.0,
+            },
+            "animalEstLLA": {
+                "latitude": -37.8136,
+                "longitude": 144.9631,
+                "altitude": 0.0,
+            },
+            "animalTrueLLA": {
+                "latitude": -37.8136,
+                "longitude": 144.9631,
+                "altitude": 0.0,
+            },
             "animalLLAUncertainty": 5.0,
             "audioClip": "base64-test-audio",
             "sampleRate": 48000,
@@ -85,6 +87,76 @@ class TestEnginePredictionOutput(unittest.TestCase):
             "http://mock-backend/engine/event",
             json=expected_payload
         )
+
+    def test_mqtt_sample_rate_used_when_provided(self):
+        mock_response = MagicMock()
+        mock_response.text = "accepted"
+        event_with_sample_rate = dict(self.audio_event)
+        event_with_sample_rate["sampleRate"] = 16000
+        event_with_sample_rate["sourceType"] = "real"
+
+        with patch.object(
+            engine_module.requests,
+            "post",
+            return_value=mock_response
+        ) as mock_post:
+            self.engine.echo_api_send_detection_event(
+                event_with_sample_rate,
+                32000,
+                "Magpie",
+                91.5,
+            )
+
+        posted_payload = mock_post.call_args.kwargs["json"]
+        self.assertEqual(posted_payload["sampleRate"], 16000)
+        self.assertEqual(posted_payload["sourceType"], "real")
+
+    def test_inference_sample_rate_used_when_mqtt_omits_it(self):
+        mock_response = MagicMock()
+        mock_response.text = "accepted"
+
+        with patch.object(
+            engine_module.requests,
+            "post",
+            return_value=mock_response
+        ) as mock_post:
+            self.engine.echo_api_send_detection_event(
+                self.audio_event,
+                32000,
+                "Magpie",
+                91.5,
+            )
+
+        posted_payload = mock_post.call_args.kwargs["json"]
+        self.assertEqual(posted_payload["sampleRate"], 32000)
+
+    def test_nullable_animal_location_fields_preserved(self):
+        mock_response = MagicMock()
+        mock_response.text = "accepted"
+        event_with_nulls = dict(self.audio_event)
+        event_with_nulls["sourceType"] = "real"
+        event_with_nulls["animalEstLLA"] = None
+        event_with_nulls["animalTrueLLA"] = None
+        event_with_nulls["animalLLAUncertainty"] = None
+        event_with_nulls["sampleRate"] = 16000
+
+        with patch.object(
+            engine_module.requests,
+            "post",
+            return_value=mock_response
+        ) as mock_post:
+            self.engine.echo_api_send_detection_event(
+                event_with_nulls,
+                32000,
+                "Magpie",
+                91.5,
+            )
+
+        posted_payload = mock_post.call_args.kwargs["json"]
+        self.assertIsNone(posted_payload["animalEstLLA"])
+        self.assertIsNone(posted_payload["animalTrueLLA"])
+        self.assertIsNone(posted_payload["animalLLAUncertainty"])
+        self.assertEqual(posted_payload["sampleRate"], 16000)
 
     def test_backend_url_read_from_configuration(self):
         expected_url = (

--- a/src/production/engine/test_iot_integration.py
+++ b/src/production/engine/test_iot_integration.py
@@ -204,9 +204,15 @@ class TestIoTMessageHandler(unittest.TestCase):
     def test_gps_coordinates_in_event(self):
         self.engine.on_iot_message(None, None, _make_msg(_valid_payload()))
         event = self.engine.echo_api_send_detection_event.call_args[0][0]
-        self.assertEqual(event["microphoneLLA"], [-37.8136, 144.9631, 0.0])
-        self.assertEqual(event["animalEstLLA"], [-37.8136, 144.9631, 0.0])
-        self.assertEqual(event["animalTrueLLA"], [-37.8136, 144.9631, 0.0])
+        expected_lla = {
+            "latitude": -37.8136,
+            "longitude": 144.9631,
+            "altitude": 0.0,
+        }
+        self.assertEqual(event["sourceType"], "real")
+        self.assertEqual(event["microphoneLLA"], expected_lla)
+        self.assertEqual(event["animalEstLLA"], expected_lla)
+        self.assertEqual(event["animalTrueLLA"], expected_lla)
 
     def test_gps_uncertainty_from_payload(self):
         self.engine.on_iot_message(None, None, _make_msg(_valid_payload(gps_uncertainty=5.0)))


### PR DESCRIPTION
## Summary

This PR updates the Project Echo Engine to support the agreed integration data contract for Simulator and real-device inputs.

## Changes

* Added MQTT input normalisation for the shared Engine input path.
* Supports the agreed standard Simulator/ESP32 payload structure.
* Preserves `sourceType` through the Engine workflow.
* Defaults legacy Simulator messages to `sourceType: "simulator"`.
* Converts legacy LLA arrays to the standard `{latitude, longitude, altitude}` structure.
* Supports nullable animal location and uncertainty fields.
* Allows standard messages without legacy `audioFile` / `mode` fields.
* Preserves the incoming `sampleRate` when supplied.
* Updated the Engine → Backend detection event to use the agreed integration schema.
* Standardised legacy IoT Engine callers to use the same LLA object structure.
* Kept existing EfficientNetV2 preprocessing and inference logic unchanged.

## Testing

* Added and updated Engine contract tests.
* Verified standard ESP32-style input handling.
* Verified legacy Simulator compatibility.
* Verified `sourceType` and `sampleRate` propagation.
* Verified object-based LLA fields and nullable animal-location fields.
* Verified malformed LLA handling.

**Result: 44 Engine unit tests passed.**

## Known dependency

The current Backend `EventSchema` may return HTTP 422 until the Backend team implements the agreed new detection-event schema. This is an expected cross-team integration dependency.
