### PR TITLE
C14.2: Add consistency checker CLI and fixture validation

### DIFF
--- a/src/production/backend/app/services/consistency_checker.py
+++ b/src/production/backend/app/services/consistency_checker.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Set
+
+from bson import ObjectId
+
+from app.database import AudioUploads, Detections, Events
+
+C14_SEED_PREFIX = "C14.2-SEED-"
+UNLINKED_AUDIO_PLACEHOLDER = "C14.2-unlinked-fixture"
+
+
+def _is_upload_reference(value: Any) -> bool:
+    if not isinstance(value, str) or len(value) != 24:
+        return False
+    try:
+        ObjectId(value)
+    except Exception:
+        return False
+    return True
+
+
+def _collect_referenced_upload_ids() -> Set[str]:
+    referenced: Set[str] = set()
+    for collection in (Detections, Events):
+        for doc in collection.find({}, {"audioClip": 1}):
+            clip = doc.get("audioClip")
+            if _is_upload_reference(clip):
+                referenced.add(clip)
+    return referenced
+
+
+def run_consistency_checks() -> List[Dict[str, Any]]:
+    issues: List[Dict[str, Any]] = []
+    upload_ids = {str(doc["_id"]) for doc in AudioUploads.find({}, {"_id": 1})}
+    referenced_upload_ids = _collect_referenced_upload_ids()
+
+    for collection_name, collection in (
+        ("detections", Detections),
+        ("events", Events),
+    ):
+        for doc in collection.find({}, {"_id": 1, "audioClip": 1, "sensorId": 1}):
+            clip = doc.get("audioClip")
+            if not _is_upload_reference(clip):
+                continue
+            if clip in upload_ids:
+                continue
+
+            issues.append(
+                {
+                    "check": "missing_audio_upload",
+                    "collection": collection_name,
+                    "record_id": str(doc["_id"]),
+                    "sensorId": doc.get("sensorId"),
+                    "audioClip": clip,
+                    "reason": "audioClip references a missing audio_uploads record",
+                }
+            )
+
+    for doc in AudioUploads.find({"fixture_marker": {"$regex": f"^{C14_SEED_PREFIX}"}}):
+        upload_id = str(doc["_id"])
+        if upload_id in referenced_upload_ids:
+            continue
+
+        issues.append(
+            {
+                "check": "orphan_audio_upload",
+                "collection": "audio_uploads",
+                "record_id": upload_id,
+                "fixture_marker": doc.get("fixture_marker"),
+                "reason": "seeded audio upload is not referenced by any detection or event",
+            }
+        )
+
+    return issues
+
+
+def apply_safe_fixes(issues: List[Dict[str, Any]]) -> Dict[str, int]:
+    fixed = {
+        "missing_audio_upload": 0,
+        "orphan_audio_upload": 0,
+    }
+
+    for issue in issues:
+        check = issue.get("check")
+
+        if check == "missing_audio_upload":
+            sensor_id = issue.get("sensorId") or ""
+            if not str(sensor_id).startswith(C14_SEED_PREFIX):
+                continue
+
+            collection = Detections if issue["collection"] == "detections" else Events
+            result = collection.update_one(
+                {"_id": ObjectId(issue["record_id"])},
+                {"$set": {"audioClip": UNLINKED_AUDIO_PLACEHOLDER}},
+            )
+            if result.modified_count:
+                fixed["missing_audio_upload"] += 1
+
+        elif check == "orphan_audio_upload":
+            marker = issue.get("fixture_marker") or ""
+            if not str(marker).startswith(C14_SEED_PREFIX):
+                continue
+
+            result = AudioUploads.delete_one({"_id": ObjectId(issue["record_id"])})
+            if result.deleted_count:
+                fixed["orphan_audio_upload"] += 1
+
+    return fixed

--- a/src/production/backend/tools/check_consistency.py
+++ b/src/production/backend/tools/check_consistency.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from app.services.consistency_checker import apply_safe_fixes, run_consistency_checks
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Report or safely fix Project Echo database consistency issues.",
+    )
+    parser.add_argument(
+        "--report-only",
+        action="store_true",
+        help="Print a report without changing the database (default).",
+    )
+    parser.add_argument(
+        "--safe-fix",
+        action="store_true",
+        help="Apply conservative fixes for C14.2-SEED fixture records only.",
+    )
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="Required with --safe-fix before any database changes are made.",
+    )
+    args = parser.parse_args()
+
+    issues = run_consistency_checks()
+
+    if args.safe_fix:
+        if not args.confirm:
+            print(
+                json.dumps(
+                    {
+                        "error": "Refusing safe-fix without --confirm",
+                        "issues_found": len(issues),
+                    },
+                    indent=2,
+                )
+            )
+            return 2
+
+        fixed = apply_safe_fixes(issues)
+        print(
+            json.dumps(
+                {
+                    "mode": "safe-fix",
+                    "issues_found": len(issues),
+                    "fixed": fixed,
+                },
+                indent=2,
+            )
+        )
+        return 0
+
+    print(
+        json.dumps(
+            {
+                "mode": "report-only",
+                "issues_found": len(issues),
+                "issues": issues,
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add report-only consistency checks for detection/event `audioClip` references to `audio_uploads`.
- Flag orphan `C14.2-SEED-*` audio uploads that are not referenced by any detection or event.
- Provide optional `--safe-fix --confirm` mode that only touches seeded fixture rows.
- Expose CLI as `python -m tools.check_consistency`.

## Test plan
- [x] Seed one valid upload + good detection link
- [x] Seed one broken detection (`audioClip` points to missing upload)
- [x] Seed one orphan upload with `C14.2-SEED-ORPHAN-01`
- [x] `--report-only` flags broken + orphan, not the good link
- [x] `--safe-fix` without `--confirm` refuses
- [x] `--safe-fix --confirm` cleans only `C14.2-SEED-*` fixtures
- [x] Re-run smoke check after review (branch includes current main; ordinary non-seed broken row left unchanged)

See latest PR comment for full CLI output from the post-merge smoke run.
