### PR TITLE
Hmi/kdl/ticket 02 detection details

### DIFF
--- a/src/production/hmi/ui/public/js/real-detections.js
+++ b/src/production/hmi/ui/public/js/real-detections.js
@@ -2,101 +2,410 @@ import { retrieveDetections, getApiErrorMessage } from "./routes.js";
 
 function validMicrophoneLLA(lla) {
   if (Array.isArray(lla)) {
-    return lla.length === 3 && lla.every(Number.isFinite) &&
-      Math.abs(lla[0]) <= 90 && Math.abs(lla[1]) <= 180;
+    return lla.length === 3 &&
+      lla.every(Number.isFinite) &&
+      Math.abs(lla[0]) <= 90 &&
+      Math.abs(lla[1]) <= 180;
   }
+
   if (lla && typeof lla === "object") {
-    return Number.isFinite(lla.latitude) && Number.isFinite(lla.longitude) &&
-      Math.abs(lla.latitude) <= 90 && Math.abs(lla.longitude) <= 180;
+    return Number.isFinite(lla.latitude) &&
+      Number.isFinite(lla.longitude) &&
+      Math.abs(lla.latitude) <= 90 &&
+      Math.abs(lla.longitude) <= 180;
   }
+
   return false;
+}
+
+function getSourceType(event) {
+  return event?.source_type ??
+    event?.sourceType ??
+    "simulator";
+}
+
+function formatDetectionValue(value) {
+  if (value === null || value === undefined || value === "") {
+    return "unavailable";
+  }
+
+  return String(value);
+}
+
+function formatConfidence(value) {
+  if (!Number.isFinite(value)) {
+    return "unavailable";
+  }
+
+  return `${value}%`;
+}
+
+function formatTimestamp(value) {
+  if (!value) {
+    return "unavailable";
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return "unavailable";
+  }
+
+  return date.toLocaleString();
+}
+
+function formatLocation(lla) {
+  if (!lla) {
+    return "unavailable";
+  }
+
+  if (Array.isArray(lla)) {
+    if (lla.length < 2) {
+      return "unavailable";
+    }
+
+    return `${lla[0]}, ${lla[1]}`;
+  }
+
+  if (
+    typeof lla === "object" &&
+    Number.isFinite(lla.latitude) &&
+    Number.isFinite(lla.longitude)
+  ) {
+    return `${lla.latitude}, ${lla.longitude}`;
+  }
+
+  return "unavailable";
+}
+
+function addDetailRow(container, label, value) {
+  const row = document.createElement("div");
+
+  const labelElement = document.createElement("strong");
+  labelElement.textContent = `${label}: `;
+
+  const valueElement = document.createElement("span");
+  valueElement.textContent = formatDetectionValue(value);
+
+  row.appendChild(labelElement);
+  row.appendChild(valueElement);
+  container.appendChild(row);
+}
+
+function showDetectionDetails(hmiState, feature) {
+  const details = hmiState.realDetectionDetails;
+
+  if (!details || !feature) return;
+
+  details.replaceChildren();
+
+  const title = document.createElement("strong");
+  title.textContent = "Detection details";
+  details.appendChild(title);
+
+  addDetailRow(
+    details,
+    "Species",
+    feature.get("species")
+  );
+
+  addDetailRow(
+    details,
+    "Confidence",
+    formatConfidence(feature.get("confidence"))
+  );
+
+  addDetailRow(
+    details,
+    "Timestamp",
+    formatTimestamp(feature.get("timestamp"))
+  );
+
+  addDetailRow(
+    details,
+    "Sensor ID",
+    feature.get("sensorId")
+  );
+
+  addDetailRow(
+    details,
+    "Source",
+    feature.get("sourceType")
+  );
+
+  addDetailRow(
+    details,
+    "Microphone location",
+    formatLocation(feature.get("microphoneLLA"))
+  );
+
+  addDetailRow(
+    details,
+    "Estimated animal location",
+    formatLocation(feature.get("animalEstLLA"))
+  );
+
+  addDetailRow(
+    details,
+    "Animal location uncertainty",
+    feature.get("animalLLAUncertainty")
+  );
+
+  details.hidden = false;
+  details.focus();
 }
 
 export async function loadRealDetections(hmiState) {
   if (!hmiState.realDetectionLayer) {
     const layer = new ol.layer.Vector({
       source: new ol.source.Vector(),
-      style: new ol.style.Style({ image: new ol.style.Circle({
-        radius: 8, fill: new ol.style.Fill({ color: "#007f73" }),
-        stroke: new ol.style.Stroke({ color: "#fff", width: 2 }),
-      }) }),
+      style: new ol.style.Style({
+        image: new ol.style.Circle({
+          radius: 8,
+          fill: new ol.style.Fill({
+            color: "#007f73",
+          }),
+          stroke: new ol.style.Stroke({
+            color: "#fff",
+            width: 2,
+          }),
+        }),
+      }),
     });
+
     layer.set("name", "real_detections");
-    // Microphone layers take z-indices near 1000 from the shared pool, and
-    // this layer is created before they exist: claim the pool top so a
-    // microphone icon never covers the detection circle at its coordinate.
+
     if (typeof layer.setZIndex === "function") {
-      layer.setZIndex(Number.isFinite(hmiState.layerPool) ? hmiState.layerPool : 1001);
-      if (Number.isFinite(hmiState.layerPool)) hmiState.layerPool -= 1;
+      layer.setZIndex(
+        Number.isFinite(hmiState.layerPool)
+          ? hmiState.layerPool
+          : 1001
+      );
+
+      if (Number.isFinite(hmiState.layerPool)) {
+        hmiState.layerPool -= 1;
+      }
     }
+
     hmiState.basemap.addLayer(layer);
     hmiState.realDetectionLayer = layer;
 
     const panel = document.createElement("div");
     panel.className = "ol-unselectable ol-control";
+
     Object.assign(panel.style, {
-      bottom: "12px", left: "12px", maxWidth: "calc(100% - 24px)",
-      padding: "8px", background: "#fff", color: "#222", fontSize: "14px",
+      bottom: "12px",
+      left: "12px",
+      maxWidth: "calc(100% - 24px)",
+      padding: "8px",
+      background: "#fff",
+      color: "#222",
+      fontSize: "14px",
     });
+
     const status = document.createElement("span");
     status.setAttribute("role", "status");
     status.setAttribute("aria-live", "polite");
+
     panel.appendChild(status);
     hmiState.realDetectionStatus = status;
+
     const refresh = document.createElement("button");
     refresh.type = "button";
     refresh.textContent = "Refresh detections";
-    Object.assign(refresh.style, { width: "auto", padding: "0 8px" });
-    refresh.addEventListener("click", () => { void loadRealDetections(hmiState); });
+
+    Object.assign(refresh.style, {
+      width: "auto",
+      padding: "0 8px",
+    });
+
+    refresh.addEventListener("click", () => {
+      void loadRealDetections(hmiState);
+    });
+
     panel.appendChild(refresh);
-    hmiState.basemap.addControl(new ol.control.Control({ element: panel }));
+
+    const details = document.createElement("div");
+    details.setAttribute("role", "region");
+    details.setAttribute(
+      "aria-label",
+      "Real detection details"
+    );
+
+    details.tabIndex = -1;
+    details.hidden = true;
+    details.style.marginTop = "8px";
+
+    panel.appendChild(details);
+    hmiState.realDetectionDetails = details;
+
+    const select = new ol.interaction.Select({
+      layers: [layer],
+    });
+
+    select.on("select", (event) => {
+      const selectedFeature = event.selected?.[0];
+
+      if (selectedFeature) {
+        showDetectionDetails(
+          hmiState,
+          selectedFeature
+        );
+      } else if (hmiState.realDetectionDetails) {
+        hmiState.realDetectionDetails.hidden = true;
+      }
+    });
+
+    hmiState.basemap.addInteraction(select);
+    hmiState.realDetectionSelect = select;
+
+    document.addEventListener("keydown", (event) => {
+      if (
+        event.key === "Escape" &&
+        hmiState.realDetectionDetails
+      ) {
+        hmiState.realDetectionDetails.hidden = true;
+
+        if (hmiState.realDetectionSelect) {
+          hmiState.realDetectionSelect
+            .getFeatures()
+            .clear();
+        }
+      }
+    });
+
+    hmiState.basemap.addControl(
+      new ol.control.Control({
+        element: panel,
+      })
+    );
   }
 
-  const request = (hmiState.realDetectionRequest || 0) + 1;
+  const request =
+    (hmiState.realDetectionRequest || 0) + 1;
+
   hmiState.realDetectionRequest = request;
-  const source = hmiState.realDetectionLayer.getSource();
-  const status = hmiState.realDetectionStatus;
-  status.textContent = "Loading real-device detections…";
+
+  const source =
+    hmiState.realDetectionLayer.getSource();
+
+  const status =
+    hmiState.realDetectionStatus;
+
+  status.textContent =
+    "Loading real-device detections…";
+
   try {
-    const response = await retrieveDetections();
-    if (request !== hmiState.realDetectionRequest) return;
-    source.clear();
-    if (!Array.isArray(response.data)) {
-      status.textContent = "The server returned invalid detection data.";
+    const response =
+      await retrieveDetections();
+
+    if (
+      request !== hmiState.realDetectionRequest
+    ) {
       return;
     }
+
+    source.clear();
+
+    if (!Array.isArray(response.data)) {
+      status.textContent =
+        "The server returned invalid detection data.";
+
+      return;
+    }
+
     let invalid = 0;
     const ids = new Set();
+
     for (const detection of response.data) {
-      if (detection?.sourceType !== "real") continue;
-      if (!validMicrophoneLLA(detection.microphoneLLA)) { invalid++; continue; }
-      if (ids.has(detection._id)) continue;
+      const sourceType = getSourceType(detection);
+
+      if (sourceType !== "real") {
+        continue;
+      }
+
+      if (
+        !validMicrophoneLLA(
+          detection.microphoneLLA
+        )
+      ) {
+        invalid++;
+        continue;
+      }
+
+      if (ids.has(detection._id)) {
+        continue;
+      }
+
       ids.add(detection._id);
-      const lat = Array.isArray(detection.microphoneLLA)
-        ? detection.microphoneLLA[0] : detection.microphoneLLA.latitude;
-      const lon = Array.isArray(detection.microphoneLLA)
-        ? detection.microphoneLLA[1] : detection.microphoneLLA.longitude;
+
+      const lat = Array.isArray(
+        detection.microphoneLLA
+      )
+        ? detection.microphoneLLA[0]
+        : detection.microphoneLLA.latitude;
+
+      const lon = Array.isArray(
+        detection.microphoneLLA
+      )
+        ? detection.microphoneLLA[1]
+        : detection.microphoneLLA.longitude;
+
       const feature = new ol.Feature({
-        ...detection, geometry: new ol.geom.Point(ol.proj.fromLonLat([lon, lat])),
+        ...detection,
+
+        // Normalize backend field name for the HMI.
+        sourceType,
+
+        geometry: new ol.geom.Point(
+          ol.proj.fromLonLat([lon, lat])
+        ),
       });
+
       feature.setId(detection._id);
       source.addFeature(feature);
     }
-    if (ids.size && !hmiState.realDetectionFitted) {
-      hmiState.basemap.getView().fit(source.getExtent(), { padding: [60, 60, 60, 60], maxZoom: 14 });
+
+    if (
+      ids.size &&
+      !hmiState.realDetectionFitted
+    ) {
+      hmiState.basemap.getView().fit(
+        source.getExtent(),
+        {
+          padding: [60, 60, 60, 60],
+          maxZoom: 14,
+        }
+      );
+
       hmiState.realDetectionFitted = true;
     }
+
     status.textContent = invalid
       ? "Some detections have invalid microphone coordinates and cannot be shown."
-      : ids.size ? `${ids.size} real-device detection${ids.size === 1 ? "" : "s"} loaded.`
+      : ids.size
+        ? `${ids.size} real-device detection${ids.size === 1 ? "" : "s"} loaded.`
         : "No real-device detections found.";
+
   } catch (error) {
-    if (request !== hmiState.realDetectionRequest) return;
+    if (
+      request !== hmiState.realDetectionRequest
+    ) {
+      return;
+    }
+
     source.clear();
-    // The shared formatter receives only status/code; provider messages stay private.
-    status.textContent = getApiErrorMessage(
-      { code: error.code, response: error.response && { status: error.response.status } },
-      "Unable to load detections. Please try again."
-    );
+
+    status.textContent =
+      getApiErrorMessage(
+        {
+          code: error.code,
+          response:
+            error.response && {
+              status: error.response.status,
+            },
+        },
+        "Unable to load detections. Please try again."
+      );
   }
 }

--- a/src/production/hmi/ui/tests/real-detections.test.mjs
+++ b/src/production/hmi/ui/tests/real-detections.test.mjs
@@ -17,6 +17,13 @@ globalThis.window = { axios: { create(options) {
 class Element {
   constructor() { this.children = []; this.style = {}; this.listeners = {}; this.classList = { add() {}, remove() {} }; }
   appendChild(el) { this.children.push(el); return el; }
+  replaceChildren(...children) {
+  this.children = [...children];
+}
+
+focus() {
+  this.focused = true;
+}
   setAttribute(key, value) { this[key] = value; }
   addEventListener(key, fn) { this.listeners[key] = fn; }
   querySelector() { return null; }
@@ -47,12 +54,63 @@ class Feature {
   get(key) { return this.properties[key]; }
 }
 class Style { constructor(options) { this.options = options; } }
+
+class Select {
+  constructor(options = {}) {
+    this.options = options;
+    this.handlers = {};
+    this.selectedFeatures = {
+      clear() {},
+    };
+  }
+
+  on(eventName, handler) {
+    this.handlers[eventName] = handler;
+  }
+
+  getFeatures() {
+    return this.selectedFeatures;
+  }
+}
+
+
 globalThis.ol = {
-  source: { Vector: Source }, layer: { Vector: Layer }, Feature,
-  geom: { Point: class { constructor(coords) { this.coords = coords; } } },
-  proj: { fromLonLat: coords => coords },
-  style: { Style, Circle: Style, Fill: Style, Stroke: Style },
-  control: { Control: class { constructor(options) { this.element = options.element; } } },
+  source: { Vector: Source },
+
+  layer: { Vector: Layer },
+
+  Feature,
+
+  geom: {
+    Point: class {
+      constructor(coords) {
+        this.coords = coords;
+      }
+    }
+  },
+
+  proj: {
+    fromLonLat: coords => coords
+  },
+
+  style: {
+    Style,
+    Circle: Style,
+    Fill: Style,
+    Stroke: Style
+  },
+
+  control: {
+    Control: class {
+      constructor(options) {
+        this.element = options.element;
+      }
+    }
+  },
+
+  interaction: {
+    Select
+  },
 };
 const routes = await import("../public/js/routes.js");
 // The production module may not exist yet during RED.
@@ -65,11 +123,47 @@ const record = {
   timestamp: "2026-08-06T10:30:00Z", sensorId: "esp32-001",
   microphoneLLA: [-37.8136, 144.9631, 0], animalTrueLLA: [10, 20, 0], animalEstLLA: [30, 40, 0],
 };
+
+const snakeCaseRealRecord = {
+  _id: "esp32-snake-case",
+  source_type: "real",
+  species: "Kookaburra",
+  confidence: 88.2,
+  timestamp: "2026-09-12T08:30:00Z",
+  sensorId: "esp32-002",
+  microphoneLLA: [-37.814, 144.964, 0],
+  animalTrueLLA: null,
+  animalEstLLA: null,
+  animalLLAUncertainty: null,
+};
+
 function state() {
-  return { basemap: { layers: [], controls: [], fits: [],
-    getView() { return { fit: (...args) => this.fits.push(args) }; },
-    addLayer(layer) { this.layers.push(layer); },
-    addControl(control) { this.controls.push(control); } } };
+  return {
+    basemap: {
+      layers: [],
+      controls: [],
+      interactions: [],
+      fits: [],
+
+      getView() {
+        return {
+          fit: (...args) => this.fits.push(args)
+        };
+      },
+
+      addLayer(layer) {
+        this.layers.push(layer);
+      },
+
+      addControl(control) {
+        this.controls.push(control);
+      },
+
+      addInteraction(interaction) {
+        this.interactions.push(interaction);
+      }
+    }
+  };
 }
 
 test("shared detection client uses same-origin endpoint and timeout", async () => {
@@ -152,6 +246,224 @@ test("simulator records never create real markers", async () => {
   await detections.loadRealDetections(hmi);
   assert.equal(hmi.realDetectionLayer.getSource().getFeatures().length, 0);
   assert.match(hmi.realDetectionStatus.textContent, /No real-device detections/);
+});
+
+test("echonet.events source_type real creates a real marker", async () => {
+  assert.ok(detections, "real detection loader exists");
+
+  const hmi = state();
+
+  result = {
+    data: [snakeCaseRealRecord]
+  };
+
+  await detections.loadRealDetections(hmi);
+
+  const features =
+    hmi.realDetectionLayer
+      .getSource()
+      .getFeatures();
+
+  assert.equal(features.length, 1);
+
+  assert.equal(
+    features[0].get("sourceType"),
+    "real"
+  );
+
+  assert.equal(
+    features[0].get("species"),
+    "Kookaburra"
+  );
+
+  assert.equal(
+    features[0].get("sensorId"),
+    "esp32-002"
+  );
+});
+
+
+test("echonet.events simulator records do not create real markers", async () => {
+  assert.ok(detections, "real detection loader exists");
+
+  const hmi = state();
+
+  result = {
+    data: [
+      {
+        ...snakeCaseRealRecord,
+        _id: "sim-event",
+        source_type: "simulator"
+      }
+    ]
+  };
+
+  await detections.loadRealDetections(hmi);
+
+  const features =
+    hmi.realDetectionLayer
+      .getSource()
+      .getFeatures();
+
+  assert.equal(features.length, 0);
+
+  assert.match(
+    hmi.realDetectionStatus.textContent,
+    /No real-device detections/
+  );
+});
+
+
+test("selecting a real marker shows its detection details", async () => {
+  assert.ok(detections, "real detection loader exists");
+
+  const hmi = state();
+
+  result = {
+    data: [snakeCaseRealRecord]
+  };
+
+  await detections.loadRealDetections(hmi);
+
+  const feature =
+    hmi.realDetectionLayer
+      .getSource()
+      .getFeatures()[0];
+
+  assert.ok(feature);
+
+  hmi.realDetectionSelect.handlers.select({
+    selected: [feature]
+  });
+
+  const details = hmi.realDetectionDetails;
+
+  assert.equal(
+    details.hidden,
+    false
+  );
+
+  assert.equal(
+    details.focused,
+    true
+  );
+
+  const text = details.children
+    .flatMap(child =>
+      child.children?.length
+        ? child.children.map(
+            grandchild => grandchild.textContent
+          )
+        : [child.textContent]
+    )
+    .filter(Boolean)
+    .join(" ");
+
+  assert.match(text, /Kookaburra/);
+  assert.match(text, /88\.2%/);
+  assert.match(text, /esp32-002/);
+  assert.match(text, /real/);
+});
+
+
+test("missing optional detection details show unavailable", async () => {
+  assert.ok(detections, "real detection loader exists");
+
+  const hmi = state();
+
+  result = {
+    data: [
+      {
+        ...snakeCaseRealRecord,
+        _id: "null-fields",
+        species: null,
+        confidence: null,
+        sensorId: null,
+        animalEstLLA: null,
+        animalLLAUncertainty: null
+      }
+    ]
+  };
+
+  await detections.loadRealDetections(hmi);
+
+  const feature =
+    hmi.realDetectionLayer
+      .getSource()
+      .getFeatures()[0];
+
+  assert.ok(feature);
+
+  hmi.realDetectionSelect.handlers.select({
+    selected: [feature]
+  });
+
+  const text =
+    hmi.realDetectionDetails.children
+      .flatMap(child =>
+        child.children?.length
+          ? child.children.map(
+              grandchild => grandchild.textContent
+            )
+          : [child.textContent]
+      )
+      .filter(Boolean)
+      .join(" ");
+
+  assert.match(
+    text,
+    /unavailable/
+  );
+});
+
+
+test("unsafe backend text is rendered as inert text", async () => {
+  assert.ok(detections, "real detection loader exists");
+
+  const hmi = state();
+
+  const unsafeSpecies =
+    "<img src=x onerror=alert(1)>";
+
+  result = {
+    data: [
+      {
+        ...snakeCaseRealRecord,
+        _id: "unsafe-record",
+        species: unsafeSpecies
+      }
+    ]
+  };
+
+  await detections.loadRealDetections(hmi);
+
+  const feature =
+    hmi.realDetectionLayer
+      .getSource()
+      .getFeatures()[0];
+
+  assert.ok(feature);
+
+  hmi.realDetectionSelect.handlers.select({
+    selected: [feature]
+  });
+
+  const text =
+    hmi.realDetectionDetails.children
+      .flatMap(child =>
+        child.children?.length
+          ? child.children.map(
+              grandchild => grandchild.textContent
+            )
+          : [child.textContent]
+      )
+      .filter(Boolean)
+      .join(" ");
+
+  assert.match(
+    text,
+    /<img src=x onerror=alert\(1\)>/
+  );
 });
 
 test("invalid object microphone coordinates never create a marker and show a safe data error", async () => {


### PR DESCRIPTION
Adds Ticket 02 HMI detection details for real-device events.

- Shows detection metadata when a real marker is selected
- Supports both source_type and sourceType
- Handles missing values as unavailable
- Renders backend text safely
- Adds tests for real/simulator source handling and detection details
- All HMI tests passing: 61/61