### PR TITLE
Add configurable detection rule engine (A3.1)

### DIFF
--- a/src/production/backend/.env.example
+++ b/src/production/backend/.env.example
@@ -15,6 +15,15 @@ MAIL_USERNAME=your_gmail_address_here
 MAIL_PASSWORD=your_gmail_app_password_here
 MAIL_FROM=your_gmail_address_here
 
+# --- Detection rule engine (A3, optional) ---
+# Applied to every incoming detection (app.detection_rules.evaluate_detection)
+# before it's persisted, via app.detections.create_detection. Change these
+# values and restart the API - no route code needs editing. Leaving a value
+# unset/empty means "no restriction" for that rule.
+# DETECTION_MIN_CONFIDENCE=80
+# DETECTION_ALLOWED_SPECIES=Koala,Sus Scrofa
+# DETECTION_ALLOWED_SENSOR_IDS=1,2
+
 # --- Docker/Kubernetes secret files (C5, optional) ---
 # Any of MONGODB_URI, USER_MONGODB_URI, JWT_SECRET, TWILIO_ACCOUNT_SID,
 # TWILIO_AUTH_TOKEN and MAIL_PASSWORD above can instead be supplied by

--- a/src/production/backend/app/config.py
+++ b/src/production/backend/app/config.py
@@ -70,6 +70,14 @@ class Settings(BaseSettings):
     log_level: str = "INFO"
     cors_origins: List[str] = ["*"]
 
+    # --- Detection rule engine (A3) ---
+    # Evaluated by app.detection_rules.evaluate_detection for every incoming
+    # detection, shared by HTTP ingestion and (once wired) A1's MQTT bridge.
+    # Empty allow-lists mean "no restriction" for that rule.
+    detection_min_confidence: float = Field(0, ge=0, le=100)
+    detection_allowed_species: List[str] = []
+    detection_allowed_sensor_ids: List[str] = []
+
     # --- Twilio (optional — SMS/2FA degrades gracefully if unset) ---
     twilio_account_sid: Optional[str] = None
     twilio_auth_token: Optional[str] = None
@@ -87,6 +95,16 @@ class Settings(BaseSettings):
     class Config:
         env_file = ".env"
         case_sensitive = False
+
+        @classmethod
+        def parse_env_var(cls, field_name: str, raw_val: str):
+            # Comma-separated lists (DETECTION_ALLOWED_SPECIES=Koala,Sus Scrofa)
+            # instead of JSON-array syntax, for these specific fields. Pydantic's
+            # default parse_env_var (cls.json_loads) still applies to every
+            # other complex-typed field (e.g. cors_origins).
+            if field_name in {"detection_allowed_species", "detection_allowed_sensor_ids"}:
+                return [item.strip() for item in raw_val.split(",") if item.strip()]
+            return cls.json_loads(raw_val)
 
         @classmethod
         def customise_sources(cls, init_settings, env_settings, file_secret_settings):

--- a/src/production/backend/app/detection_rules.py
+++ b/src/production/backend/app/detection_rules.py
@@ -1,0 +1,79 @@
+## app.detection_rules.py
+# Configurable evaluation of incoming detections against operator-defined
+# rules, applied before persistence/streaming. Rule values come from
+# app.config.settings (see C4) rather than being hardcoded in a route, and
+# the evaluator itself is transport-agnostic so both HTTP ingestion
+# (app.detections.create_detection) and A1's future MQTT ingestion bridge
+# can call the same logic and get the same accept/reject decision.
+import logging
+from typing import List, Tuple
+
+from pydantic import BaseModel, confloat
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class DetectionRules(BaseModel):
+    """A single rule set. Empty allow-lists mean 'no restriction' for that rule."""
+
+    min_confidence: confloat(ge=0, le=100) = 0
+    allowed_species: List[str] = []
+    allowed_sensor_ids: List[str] = []
+
+
+def get_active_rules() -> DetectionRules:
+    """Build the current rule set from configuration.
+
+    Re-reads app.config.settings on every call (not cached at import time)
+    so config changes take effect without restarting long-lived state, and
+    so a per-request rule override (e.g. in tests) can pass its own
+    DetectionRules instead of calling this at all.
+    """
+    return DetectionRules(
+        min_confidence=settings.detection_min_confidence,
+        allowed_species=settings.detection_allowed_species,
+        allowed_sensor_ids=settings.detection_allowed_sensor_ids,
+    )
+
+
+def evaluate_detection(detection, rules: DetectionRules = None) -> Tuple[bool, str]:
+    """Evaluate one detection against `rules` (or the active configured rules).
+
+    `detection` needs .confidence (0-100 float), .species (str) and
+    .sensorId (str) attributes - satisfied by both DetectionCreate/Detection
+    (schemas.EventSchema) and the MQTT-side event payload A1 will parse.
+
+    Returns (accepted, reason). `reason` is a stable machine-readable code
+    ("accepted", "below_min_confidence", "species_not_allowed",
+    "sensor_not_allowed") suitable for logging and for surfacing to API
+    clients - never raises for a rule violation, so callers decide how to
+    respond (HTTP 422, MQTT drop-and-log, etc).
+    """
+    if rules is None:
+        rules = get_active_rules()
+
+    if detection.confidence < rules.min_confidence:
+        return False, "below_min_confidence"
+    if rules.allowed_species and detection.species not in rules.allowed_species:
+        return False, "species_not_allowed"
+    if rules.allowed_sensor_ids and detection.sensorId not in rules.allowed_sensor_ids:
+        return False, "sensor_not_allowed"
+    return True, "accepted"
+
+
+def log_rejected_detection(detection, reason: str) -> None:
+    """Log a rule-rejected detection. No audioClip/binary data.
+
+    logging_config.JsonFormatter only serialises the formatted message (it
+    does not read LogRecord.extra), so the context is embedded in the
+    message itself rather than passed via `extra=`.
+    """
+    logger.info(
+        "detection_rejected reason=%s sensorId=%s species=%s confidence=%s",
+        reason,
+        getattr(detection, "sensorId", None),
+        getattr(detection, "species", None),
+        getattr(detection, "confidence", None),
+    )

--- a/src/production/backend/app/detections.py
+++ b/src/production/backend/app/detections.py
@@ -7,6 +7,7 @@ from pymongo import ReturnDocument
 
 from app.database import Detections
 from app.schemas import DetectionCreate, Detection
+from app.detection_rules import evaluate_detection, log_rejected_detection
 
 def _doc_to_detection(doc: Dict[str, Any]) -> Optional[Detection]:
     if not doc:
@@ -15,6 +16,11 @@ def _doc_to_detection(doc: Dict[str, Any]) -> Optional[Detection]:
 
 
 def create_detection(detection_in: DetectionCreate) -> Detection:
+    accepted, reason = evaluate_detection(detection_in)
+    if not accepted:
+        log_rejected_detection(detection_in, reason)
+        raise HTTPException(status_code=422, detail=f"Detection rejected: {reason}")
+
     payload = detection_in.dict(by_alias=True)
 
     result = Detections.insert_one(payload)

--- a/src/production/backend/test_detection_rules.py
+++ b/src/production/backend/test_detection_rules.py
@@ -1,0 +1,121 @@
+"""
+Tests for app.detection_rules.
+
+Run inside the API container / with the backend's requirements installed:
+    python -m unittest test_detection_rules -v
+"""
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+REQUIRED_ENV = {
+    "MONGODB_URI": "mongodb://user:pass@localhost:27017/EchoNet",
+    "USER_MONGODB_URI": "mongodb://user:pass@localhost:27017/UserSample",
+    "JWT_SECRET": "test-secret",
+}
+os.environ.setdefault("MONGODB_URI", REQUIRED_ENV["MONGODB_URI"])
+os.environ.setdefault("USER_MONGODB_URI", REQUIRED_ENV["USER_MONGODB_URI"])
+os.environ.setdefault("JWT_SECRET", REQUIRED_ENV["JWT_SECRET"])
+
+from pydantic import ValidationError
+
+from app.config import Settings
+from app.detection_rules import DetectionRules, evaluate_detection, get_active_rules
+
+
+def _detection(confidence=90.0, species="Koala", sensorId="1"):
+    return SimpleNamespace(confidence=confidence, species=species, sensorId=sensorId)
+
+
+class TestEvaluateDetection(unittest.TestCase):
+    def test_accepted_when_no_restrictions(self):
+        rules = DetectionRules()
+        accepted, reason = evaluate_detection(_detection(), rules)
+        self.assertTrue(accepted)
+        self.assertEqual(reason, "accepted")
+
+    def test_rejected_below_min_confidence(self):
+        rules = DetectionRules(min_confidence=80)
+        accepted, reason = evaluate_detection(_detection(confidence=50.0), rules)
+        self.assertFalse(accepted)
+        self.assertEqual(reason, "below_min_confidence")
+
+    def test_accepted_at_exactly_min_confidence(self):
+        rules = DetectionRules(min_confidence=80)
+        accepted, reason = evaluate_detection(_detection(confidence=80.0), rules)
+        self.assertTrue(accepted)
+        self.assertEqual(reason, "accepted")
+
+    def test_rejected_species_not_allowed(self):
+        rules = DetectionRules(allowed_species=["Sus Scrofa"])
+        accepted, reason = evaluate_detection(_detection(species="Koala"), rules)
+        self.assertFalse(accepted)
+        self.assertEqual(reason, "species_not_allowed")
+
+    def test_accepted_species_in_allow_list(self):
+        rules = DetectionRules(allowed_species=["Koala", "Sus Scrofa"])
+        accepted, reason = evaluate_detection(_detection(species="Koala"), rules)
+        self.assertTrue(accepted)
+
+    def test_rejected_sensor_not_allowed(self):
+        rules = DetectionRules(allowed_sensor_ids=["2"])
+        accepted, reason = evaluate_detection(_detection(sensorId="1"), rules)
+        self.assertFalse(accepted)
+        self.assertEqual(reason, "sensor_not_allowed")
+
+    def test_empty_allow_lists_mean_no_restriction(self):
+        rules = DetectionRules(allowed_species=[], allowed_sensor_ids=[])
+        accepted, _ = evaluate_detection(_detection(species="anything", sensorId="anything"), rules)
+        self.assertTrue(accepted)
+
+    def test_rules_checked_in_order_confidence_first(self):
+        # A detection that fails multiple rules should report the first one checked.
+        rules = DetectionRules(min_confidence=80, allowed_species=["Sus Scrofa"])
+        accepted, reason = evaluate_detection(_detection(confidence=10.0, species="Koala"), rules)
+        self.assertFalse(accepted)
+        self.assertEqual(reason, "below_min_confidence")
+
+
+class TestDetectionRulesValidation(unittest.TestCase):
+    def test_min_confidence_over_100_rejected(self):
+        with self.assertRaises(ValidationError):
+            DetectionRules(min_confidence=150)
+
+    def test_min_confidence_negative_rejected(self):
+        with self.assertRaises(ValidationError):
+            DetectionRules(min_confidence=-1)
+
+    def test_defaults_impose_no_restriction(self):
+        rules = DetectionRules()
+        self.assertEqual(rules.min_confidence, 0)
+        self.assertEqual(rules.allowed_species, [])
+        self.assertEqual(rules.allowed_sensor_ids, [])
+
+
+class TestGetActiveRulesFromSettings(unittest.TestCase):
+    def test_reads_configured_thresholds(self):
+        env = {
+            **REQUIRED_ENV,
+            "DETECTION_MIN_CONFIDENCE": "75",
+            "DETECTION_ALLOWED_SPECIES": "Koala,Sus Scrofa",
+            "DETECTION_ALLOWED_SENSOR_IDS": "1, 2",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            settings = Settings()
+        self.assertEqual(settings.detection_min_confidence, 75)
+        self.assertEqual(settings.detection_allowed_species, ["Koala", "Sus Scrofa"])
+        self.assertEqual(settings.detection_allowed_sensor_ids, ["1", "2"])
+
+    def test_get_active_rules_uses_module_level_settings(self):
+        with patch("app.detection_rules.settings") as mock_settings:
+            mock_settings.detection_min_confidence = 60
+            mock_settings.detection_allowed_species = ["Koala"]
+            mock_settings.detection_allowed_sensor_ids = []
+            rules = get_active_rules()
+        self.assertEqual(rules.min_confidence, 60)
+        self.assertEqual(rules.allowed_species, ["Koala"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Introduce app/detection_rules.py: a DetectionRules model plus evaluate_detection(), applied to every incoming detection before it's persisted (app.detections.create_detection). Checks three configurable rules in order - min_confidence, allowed_species, allowed_sensor_ids - each returning a stable machine-readable reason (below_min_confidence, species_not_allowed, sensor_not_allowed) instead of a generic rejection. A rejected detection returns 422 and logs the reason server-side, never the audio payload.

Rule values are read through the C4 Settings model rather than hardcoded in the route: DETECTION_MIN_CONFIDENCE, DETECTION_ALLOWED_SPECIES, DETECTION_ALLOWED_SENSOR_IDS. Settings.Config.parse_env_var is extended so the two list fields accept plain comma-separated values in .env instead of requiring JSON-array syntax. Leaving all three unset preserves today's behaviour exactly (no restrictions).

evaluate_detection() takes a plain object with .confidence/.species/ .sensorId rather than anything HTTP-specific, so A1's MQTT ingestion bridge can call the same function once it exists, instead of duplicating the rule logic for a second ingestion path.

Adds 13 unit tests (accept/reject per rule, the min_confidence boundary, empty allow-lists meaning no restriction, invalid rule values rejected by validation, and env parsing) plus .env.example documentation. Verified live against the real API container: default config behaves identically to pre-A3 (regression-safe), and a configured min_confidence/ allowed_species combination correctly rejects/accepts through the actual POST /detections route.